### PR TITLE
fix: set default panel sizes to 15% left/right

### DIFF
--- a/apps/desktop/src/components/layout/AppLayout.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.tsx
@@ -14,9 +14,9 @@ export function AppLayout({ children, className = "" }: AppLayoutProps) {
   const handleLayoutChange = (layout: Layout) => {
     // Layout is a map of panel id to percentage (0..100)
     const newSizes: PanelSizes = {
-      sidebar: layout["sidebar"] ?? 20,
-      main: layout["main-content"] ?? 55,
-      detail: layout["detail-panel"] ?? 25,
+      sidebar: layout["sidebar"] ?? 15,
+      main: layout["main-content"] ?? 70,
+      detail: layout["detail-panel"] ?? 15,
     };
     setPanelSizes(newSizes);
   };

--- a/apps/desktop/src/components/layout/DetailPanel.tsx
+++ b/apps/desktop/src/components/layout/DetailPanel.tsx
@@ -10,7 +10,7 @@ interface DetailPanelProps {
 
 export function DetailPanel({
   children,
-  defaultSize = 25,
+  defaultSize = 15,
   minSize = 15,
   className = "",
 }: DetailPanelProps) {

--- a/apps/desktop/src/components/layout/MainContent.tsx
+++ b/apps/desktop/src/components/layout/MainContent.tsx
@@ -10,7 +10,7 @@ interface MainContentProps {
 
 export function MainContent({
   children,
-  defaultSize = 55,
+  defaultSize = 70,
   minSize = 30,
   className = "",
 }: MainContentProps) {

--- a/apps/desktop/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ interface SidebarProps {
 
 export function Sidebar({
   children,
-  defaultSize = 20,
+  defaultSize = 15,
   minSize = 15,
   className = "",
 }: SidebarProps) {

--- a/apps/desktop/src/stores/layoutStore.ts
+++ b/apps/desktop/src/stores/layoutStore.ts
@@ -6,9 +6,9 @@ export type ViewType = 'terminal' | 'kanban';
 
 // Default panel sizes (percentages)
 const DEFAULT_SIZES = {
-  sidebar: 20,
-  main: 55,
-  detail: 25,
+  sidebar: 15,
+  main: 70,
+  detail: 15,
 } as const;
 
 export interface PanelSizes {


### PR DESCRIPTION
## Summary
- Changed default sidebar (left) panel from 20% to 15%
- Changed default detail (right) panel from 25% to 15%
- Center panel now defaults to 70% (was 55%)
- Updated all layout wrapper components for consistency

Closes #72

## Test plan
- [ ] Clear localStorage (`tiki-layout` key) and verify panels default to 15/70/15
- [ ] Click "Reset Layout" button and verify it restores 15/70/15
- [ ] Verify panel resizing still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)