### PR TITLE
feat: display project name in center of top header bar

### DIFF
--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -45,11 +45,29 @@
 /* Header */
 .header {
   display: flex;
-  align-items: baseline;
-  gap: 12px;
-  padding: 16px 24px;
+  align-items: center;
+  padding: 8px 24px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(0, 0, 0, 0.2);
+}
+
+.header-left {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.header-center {
+  flex: 1;
+  text-align: center;
+  min-width: 0;
+}
+
+.header-right {
+  flex: 1;
+  min-width: 0;
 }
 
 .header h1 {
@@ -61,6 +79,13 @@
 .header .subtitle {
   color: rgba(255, 255, 255, 0.5);
   font-size: 0.875rem;
+}
+
+.project-title {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.02em;
 }
 
 /* Main Content */

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -187,8 +187,14 @@ function App() {
   return (
     <div className="app">
       <header className="header">
-        <h1>Tiki</h1>
-        <span className="subtitle">GitHub Issue Workflow</span>
+        <div className="header-left">
+          <h1>Tiki</h1>
+          <span className="subtitle">GitHub Issue Workflow</span>
+        </div>
+        <div className="header-center">
+          {activeProject && <span className="project-title">{activeProject.name}</span>}
+        </div>
+        <div className="header-right" />
       </header>
 
       <Group orientation="horizontal" className="app-layout">


### PR DESCRIPTION
## Summary
- Added active project name to the center of the top header bar
- Header now has three-section layout: Tiki branding (left), project name (center), spacer (right)
- When no project is active, the center area remains empty
- Styled with muted text to complement existing dark theme

Closes #73

## Test plan
- [ ] Select a project and verify its name appears centered in the header
- [ ] Switch projects and verify the title updates immediately
- [ ] With no project selected, verify the center area is empty
- [ ] Verify header layout looks balanced at different window widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)