### PR TITLE
feat: auto-increment release version when creating new release

### DIFF
--- a/apps/desktop/src/components/releases/ReleaseDialog.tsx
+++ b/apps/desktop/src/components/releases/ReleaseDialog.tsx
@@ -8,6 +8,7 @@ export interface ReleaseDialogProps {
   onClose: () => void;
   onSave: (release: Omit<TikiRelease, "createdAt" | "updatedAt">) => void;
   editingRelease?: TikiRelease;
+  suggestedVersion?: string;
 }
 
 export function ReleaseDialog({
@@ -15,6 +16,7 @@ export function ReleaseDialog({
   onClose,
   onSave,
   editingRelease,
+  suggestedVersion,
 }: ReleaseDialogProps) {
   const [version, setVersion] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -66,12 +68,12 @@ export function ReleaseDialog({
         setVersion(editingRelease.version);
         setSelectedIssues([...editingRelease.issues]);
       } else {
-        setVersion("");
+        setVersion(suggestedVersion ?? "");
         setSelectedIssues([]);
       }
       setError(null);
     }
-  }, [isOpen, editingRelease]);
+  }, [isOpen, editingRelease, suggestedVersion]);
 
   // Fetch open issues when dialog opens
   useEffect(() => {

--- a/apps/desktop/src/components/sidebar/ReleasesSection.tsx
+++ b/apps/desktop/src/components/sidebar/ReleasesSection.tsx
@@ -299,6 +299,24 @@ export function ReleasesSection() {
     </div>
   );
 
+  // Compute suggested next version by incrementing the patch of the highest existing version
+  const suggestedVersion = useMemo(() => {
+    const versions = mergedReleases.map((r) => r.version);
+    if (versions.length === 0) return "v0.1.0";
+    const sorted = [...versions].sort((a, b) => {
+      const pa = a.replace(/^v/, "").split(".").map(Number);
+      const pb = b.replace(/^v/, "").split(".").map(Number);
+      for (let i = 0; i < 3; i++) {
+        if ((pa[i] || 0) !== (pb[i] || 0)) return (pb[i] || 0) - (pa[i] || 0);
+      }
+      return 0;
+    });
+    const latest = sorted[0].replace(/-.*$/, ""); // strip pre-release suffix
+    const parts = latest.replace(/^v/, "").split(".").map(Number);
+    parts[2] = (parts[2] || 0) + 1;
+    return `v${parts.join(".")}`;
+  }, [mergedReleases]);
+
   const totalCount = mergedReleases.length;
 
   return (
@@ -399,6 +417,7 @@ export function ReleasesSection() {
         onClose={handleDialogClose}
         onSave={handleDialogSave}
         editingRelease={editingRelease}
+        suggestedVersion={suggestedVersion}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- Pre-fill version field with next patch version when creating a new release
- Computes highest version across both GitHub and Tiki releases using proper semver comparison
- Handles pre-release suffixes (strips them before incrementing)
- Defaults to v0.1.0 when no releases exist
- Version field remains fully editable

Closes #74

## Test plan
- [ ] With existing releases (e.g., v0.2.1), click "+" to create new release and verify version is pre-filled with v0.2.2
- [ ] Edit an existing release and verify version shows the existing version (not incremented)
- [ ] With no releases, verify default is v0.1.0
- [ ] Verify the pre-filled version can be freely edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)