### PR TITLE
feat: sort completed kanban items by most recent first

### DIFF
--- a/apps/desktop/src/components/kanban/KanbanBoard.tsx
+++ b/apps/desktop/src/components/kanban/KanbanBoard.tsx
@@ -299,7 +299,10 @@ export function KanbanBoard() {
     const result = COLUMN_CONFIG.map((col) => {
       // For the completed column, use recentIssues from history (limited to 8)
       if (col.id === 'completed') {
-        const completedIssues: GitHubIssue[] = recentIssues.slice(0, 8).map((recent) => ({
+        const completedIssues: GitHubIssue[] = [...recentIssues]
+          .sort((a, b) => new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime())
+          .slice(0, 8)
+          .map((recent) => ({
           number: recent.number,
           title: recent.title || `Issue #${recent.number}`,
           state: 'CLOSED',


### PR DESCRIPTION
## Summary
- Sort completed kanban column items by `completedAt` timestamp in descending order (most recently completed first)
- Fixes #79

## Changes
- `apps/desktop/src/components/kanban/KanbanBoard.tsx`: Added `.sort()` by `completedAt` descending before `.slice(0, 8)` in the completed column logic

## Test plan
- [ ] Verify completed items appear with most recently completed at the top
- [ ] Verify no more than 8 items are shown
- [ ] Verify typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)