### PR TITLE
feat: show issue details when clicking kanban cards

### DIFF
--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -318,7 +318,8 @@ pub fn create_github_issue(
 }
 
 /// Fetch a single GitHub issue by number
-fn fetch_github_issue_by_number(
+#[tauri::command]
+pub fn fetch_github_issue_by_number(
     number: u32,
     project_path: Option<String>,
 ) -> Result<GitHubIssue, String> {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -48,6 +48,7 @@ pub fn run() {
             github::create_github_issue,
             github::edit_github_issue,
             github::close_github_issue,
+            github::fetch_github_issue_by_number,
             github::enhance_issue_description,
             github::get_current_branch,
             github::list_git_branches,


### PR DESCRIPTION
## Summary
- Expose `fetch_github_issue_by_number` as a public Tauri command for on-demand single-issue fetching
- Add on-demand issue fetching in `App.tsx` when a selected issue isn't in the issues store (e.g. completed/closed issues from kanban)
- Clicking any kanban card now shows full issue details in the right panel, including completed items
- Fixes #80

## Changes
- `apps/desktop/src-tauri/src/github.rs`: Made `fetch_github_issue_by_number` public with `#[tauri::command]`
- `apps/desktop/src-tauri/src/lib.rs`: Registered the new command in `invoke_handler`
- `apps/desktop/src/App.tsx`: Added `fetchedIssue` state and `useEffect` to fetch issue details on demand when not found in the store

## Test plan
- [ ] Click an open issue card in kanban - detail panel shows issue info
- [ ] Click a completed issue card in kanban - detail panel fetches and shows issue info
- [ ] Switch between different cards - detail panel updates correctly
- [ ] Typecheck passes (`pnpm typecheck`)
- [ ] Rust compiles (`cargo check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)