### PR TITLE
feat: research command and knowledge capture (#102)

### DIFF
--- a/.tiki/plans/issue-102.json
+++ b/.tiki/plans/issue-102.json
@@ -1,0 +1,181 @@
+{
+  "schemaVersion": 1,
+  "issue": {
+    "number": 102,
+    "title": "Research command and knowledge capture",
+    "url": "https://github.com/Eric-Ness/Tiki-V2/issues/102"
+  },
+  "createdAt": "2026-05-09T02:05:00.000Z",
+  "successCriteria": [
+    { "id": "SC1", "category": "functionality", "description": "Running /tiki:research <topic> captures a well-formed .tiki/research/<topic>.md file with YAML front-matter and markdown body" },
+    { "id": "SC2", "category": "functionality", "description": "Front-matter schema (topic, tags, issues, created) is defined and written correctly by the research command; issues field is auto-tagged with the current issue number when provided" },
+    { "id": "SC3", "category": "functionality", "description": "review.md auto-captures domain findings to .tiki/research/ as a side-effect of the REVIEW step" },
+    { "id": "SC4", "category": "functionality", "description": "plan.md auto-captures planning-relevant domain knowledge to .tiki/research/ as a side-effect of the PLAN step" },
+    { "id": "SC5", "category": "functionality", "description": "plan.md reads existing .tiki/research/ docs before phase design and surfaces relevant content to the planner" },
+    { "id": "SC6", "category": "functionality", "description": "execute.md reads relevant .tiki/research/ docs before each phase and passes content to sub-agents via the phase context" },
+    { "id": "SC7", "category": "functionality", "description": "list_research_docs and read_research_doc Rust IPC commands exist, are registered in lib.rs, and return correct data" },
+    { "id": "SC8", "category": "functionality", "description": "The file watcher emits a ResearchChanged event (with filename) when any .tiki/research/*.md file is created, modified, or deleted" },
+    { "id": "SC9", "category": "ux", "description": "The desktop sidebar shows a ResearchSection listing all research docs with topic and tags; the list updates live when files change" },
+    { "id": "SC10", "category": "ux", "description": "Selecting a research doc in the sidebar renders its Markdown body (front-matter stripped) in the detail panel via the existing MarkdownRenderer component" },
+    { "id": "SC11", "category": "functionality", "description": "Framework command mirrors in packages/framework/.claude/commands/tiki/ are updated to match their source files, and pnpm build passes from repo root with no TypeScript or Rust errors" }
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "title": "Manual research command and front-matter schema",
+      "status": "pending",
+      "content": "Create packages/framework/commands/research.md defining the /tiki:research <topic> manual capture command. The command must: (1) parse the topic argument and optional --issue flag; (2) prompt the user for the knowledge to capture if not piped; (3) write .tiki/research/<topic>.md with YAML front-matter (topic, tags, issues, created) followed by the markdown body.\n\nAlso create .tiki/research/example-research.md as a seed document to validate the format and give sub-agents a reference. The example should use a realistic topic (e.g. 'github-api') and include all front-matter fields.\n\nThe command file follows the same hybrid Markdown+XML format as packages/framework/commands/get.md: YAML front-matter header (name, description, argument, tools), then #-heading sections, then XML <instructions>, <output>, and <errors> blocks.\n\nThe schema for every research doc is:\n---\ntopic: <slug>\ntags: [tag1, tag2]\nissues: [42, 87]\ncreated: <ISO 8601 timestamp>\n---\n(markdown body)",
+      "verification": [
+        "packages/framework/commands/research.md exists with correct YAML front-matter (name: research, argument: <topic>)",
+        "research.md <instructions> block describes writing .tiki/research/<topic>.md with the defined front-matter schema",
+        ".tiki/research/example-research.md exists with all four front-matter fields populated",
+        "No build or typecheck step needed for this phase (pure markdown); manual review of both files suffices"
+      ],
+      "addressesCriteria": ["SC1", "SC2"],
+      "files": [
+        "packages/framework/commands/research.md",
+        ".tiki/research/example-research.md"
+      ],
+      "dependencies": []
+    },
+    {
+      "number": 2,
+      "title": "Auto-capture wiring in review.md and plan.md",
+      "status": "pending",
+      "content": "Edit packages/framework/commands/review.md and packages/framework/commands/plan.md to instruct Claude to write research docs as a side-effect.\n\nIn review.md: add a <research-capture> XML section (after the existing <output> block) that instructs Claude to — if any notable domain knowledge was discovered during codebase exploration (architecture patterns, auth flows, data models, external API usage, etc.) — write one or more .tiki/research/<topic>.md files using the schema from phase 1. The section should specify: use a kebab-case topic slug; set tags to the relevant categories; set issues to [<current issue number>]; set created to now. Claude should only write a file if there is meaningful non-trivial knowledge to capture; skip if the issue is purely a bug fix with no domain learning.\n\nIn plan.md: add the same <research-capture> XML section instructing Claude to capture planning-relevant knowledge (e.g. 'discovered that auth uses JWT with RS256 key rotation') discovered while exploring the codebase during planning.",
+      "verification": [
+        "packages/framework/commands/review.md contains a <research-capture> section explaining when and how to write .tiki/research/*.md files",
+        "packages/framework/commands/plan.md contains an equivalent <research-capture> section",
+        "Both sections reference the YAML front-matter schema (topic, tags, issues, created)",
+        "No build step needed; manual review of both files suffices"
+      ],
+      "addressesCriteria": ["SC3", "SC4"],
+      "files": [
+        "packages/framework/commands/review.md",
+        "packages/framework/commands/plan.md"
+      ],
+      "dependencies": [1]
+    },
+    {
+      "number": 3,
+      "title": "Auto-retrieval wiring in plan.md and execute.md",
+      "status": "pending",
+      "content": "Edit packages/framework/commands/plan.md and packages/framework/commands/execute.md to instruct Claude to read existing research docs before doing its main work.\n\nIn plan.md: add a <research-retrieval> XML section as an early step (before phase design begins) that instructs Claude to: (1) list files in .tiki/research/; (2) for each file, read its front-matter to check if tags or issues are relevant to the current issue; (3) read the full body of relevant docs; (4) summarize what was found in a 'Research Context' block before proceeding to phase design. If no research docs exist, skip silently.\n\nIn execute.md: add the same <research-retrieval> section as an early step (before sub-agent task dispatch) instructing Claude to read relevant research docs and include their content in the context passed to each Task sub-agent. The execute command should pass research content in the task prompt under a ## Research Context heading.",
+      "verification": [
+        "packages/framework/commands/plan.md contains a <research-retrieval> section as a step before phase design",
+        "packages/framework/commands/execute.md contains a <research-retrieval> section before Task dispatch",
+        "Both sections describe checking .tiki/research/ for relevant docs by matching tags or issue numbers",
+        "No build step needed; manual review of both files suffices"
+      ],
+      "addressesCriteria": ["SC5", "SC6"],
+      "files": [
+        "packages/framework/commands/plan.md",
+        "packages/framework/commands/execute.md"
+      ],
+      "dependencies": [1]
+    },
+    {
+      "number": 4,
+      "title": "Rust IPC commands and watcher ResearchChanged event",
+      "status": "pending",
+      "content": "Three changes to the Rust backend:\n\n1. commands.rs: Add list_research_docs(tiki_path: Option<String>) -> Result<Vec<ResearchDocMeta>, String>. ResearchDocMeta is a #[derive(Serialize)] struct with fields: filename: String, topic: String, tags: Vec<String>, issues: Vec<u32>, created: String. The command reads .tiki/research/*.md, parses YAML front-matter for each file (use a simple line-by-line parser — just read lines between the --- delimiters and split on ': '), and returns the metadata array sorted by created descending. Files with missing or malformed front-matter are skipped with a warn! log.\n\n2. commands.rs: Add read_research_doc(filename: String, tiki_path: Option<String>) -> Result<String, String>. Returns the full raw file contents (including front-matter). Filename must have .md extension (validate to prevent path traversal). Use resolve_tiki_path and read from the research/ subdirectory.\n\n3. watcher.rs: Add ResearchChanged { filename: String } variant to TikiFileEvent. In process_event, add an arm that checks if the path is inside the research/ directory (add is_in_research_dir helper mirroring is_in_releases_dir). If so, return ResearchChanged { filename: name.to_string() }. In debounce_key, add the arm: TikiFileEvent::ResearchChanged { filename } => format!(\"research-{}\", filename).\n\nRegister both new commands in lib.rs invoke_handler.\n\ncargo check in apps/desktop/src-tauri must pass.",
+      "verification": [
+        "cargo check in apps/desktop/src-tauri passes with no errors",
+        "ResearchDocMeta struct is defined with filename, topic, tags, issues, created fields",
+        "list_research_docs is registered in tauri::generate_handler! in lib.rs",
+        "read_research_doc is registered in tauri::generate_handler! in lib.rs",
+        "ResearchChanged { filename } variant exists in TikiFileEvent enum",
+        "process_event returns ResearchChanged for files in .tiki/research/",
+        "debounce_key handles ResearchChanged with key research-{filename}"
+      ],
+      "addressesCriteria": ["SC7", "SC8"],
+      "files": [
+        "apps/desktop/src-tauri/src/commands.rs",
+        "apps/desktop/src-tauri/src/lib.rs",
+        "apps/desktop/src-tauri/src/watcher.rs"
+      ],
+      "dependencies": []
+    },
+    {
+      "number": 5,
+      "title": "Frontend research store and sidebar ResearchSection",
+      "status": "pending",
+      "content": "Two new frontend files:\n\n1. apps/desktop/src/stores/researchStore.ts: Create a Zustand store (no persist — reloaded from disk on demand) following the tikiReleasesStore.ts pattern. State: docs: ResearchDocMeta[], isLoading: boolean, error: string | null. Actions: setDocs, setLoading, setError, clearError. Export ResearchDocMeta interface (filename, topic, tags, issues, created — mirrors the Rust struct).\n\n2. apps/desktop/src/components/sidebar/ResearchSection.tsx + ResearchSection.css: Follow the ReleasesSection.tsx pattern. On mount (and when activeProject changes), call invoke<ResearchDocMeta[]>('list_research_docs', { tikiPath }) and populate the store. Render a CollapsibleSection with title 'Research' and a book/document SVG icon. Each doc renders as a card showing topic (bold) and tags as small badges. Clicking a card calls setSelectedResearchDoc(doc.filename) from detailStore. Show an empty state message if no docs exist. The ResearchChanged file event (wired in phase 7 via App.tsx) will re-invoke list_research_docs to refresh.\n\nCSS: .research-section-card, .research-section-card.selected, .research-section-topic, .research-section-tags, .research-section-tag, .research-section-empty, .research-section-loading.",
+      "verification": [
+        "apps/desktop/src/stores/researchStore.ts exists and exports useResearchStore and ResearchDocMeta",
+        "apps/desktop/src/components/sidebar/ResearchSection.tsx exists and renders a CollapsibleSection",
+        "ResearchSection.css exists and is imported by ResearchSection.tsx",
+        "ResearchSection calls list_research_docs on mount and populates researchStore",
+        "pnpm typecheck from repo root passes (ResearchSection not yet mounted in App.tsx — that is phase 7)"
+      ],
+      "addressesCriteria": ["SC9"],
+      "files": [
+        "apps/desktop/src/stores/researchStore.ts",
+        "apps/desktop/src/components/sidebar/ResearchSection.tsx",
+        "apps/desktop/src/components/sidebar/ResearchSection.css"
+      ],
+      "dependencies": [4]
+    },
+    {
+      "number": 6,
+      "title": "Frontend detail panel for research docs",
+      "status": "pending",
+      "content": "Three changes:\n\n1. apps/desktop/src/stores/detailStore.ts: Add selectedResearchDoc: string | null to ProjectSelection (default null). Add setSelectedResearchDoc(filename: string | null) action. The setter must null out all other selection fields (selectedIssue, selectedRelease, selectedTikiRelease, selectedPr) so the detail panel shows only research. Add to emptySelection. The persist store name stays 'tiki-detail'.\n\n2. apps/desktop/src/components/detail/ResearchDetail.tsx: Component that receives filename: string and activeProject path. On mount it calls invoke<string>('read_research_doc', { filename, tikiPath }) to load raw content. Strip YAML front-matter (everything between the first two '---' delimiters) to get the markdown body. Pass body to the existing <MarkdownRenderer> component. Show a loading spinner while fetching and an error message on failure. Display topic and tags from the front-matter as a header above the markdown body.\n\n3. apps/desktop/src/components/detail/ResearchDetail.css: .research-detail-header, .research-detail-topic, .research-detail-tags, .research-detail-tag, .research-detail-body, .research-detail-loading, .research-detail-error.\n\n4. apps/desktop/src/components/detail/index.ts: Add export for ResearchDetail.\n\npnpm build from repo root must pass.",
+      "verification": [
+        "detailStore.ts ProjectSelection includes selectedResearchDoc: string | null",
+        "setSelectedResearchDoc action nulls out all other selection fields",
+        "ResearchDetail.tsx exists, imports MarkdownRenderer, strips front-matter before rendering",
+        "ResearchDetail.css exists and is imported by ResearchDetail.tsx",
+        "apps/desktop/src/components/detail/index.ts exports ResearchDetail",
+        "pnpm build from repo root passes with no TypeScript errors"
+      ],
+      "addressesCriteria": ["SC10"],
+      "files": [
+        "apps/desktop/src/stores/detailStore.ts",
+        "apps/desktop/src/components/detail/ResearchDetail.tsx",
+        "apps/desktop/src/components/detail/ResearchDetail.css",
+        "apps/desktop/src/components/detail/index.ts"
+      ],
+      "dependencies": [5]
+    },
+    {
+      "number": 7,
+      "title": "App wiring, mirror sync, and final build",
+      "status": "pending",
+      "content": "Wire everything together and synchronize mirrors:\n\n1. apps/desktop/src/App.tsx: (a) Import ResearchSection and mount it in the sidebar after ReleasesSection. (b) Import ResearchDetail. (c) Read selectedResearchDoc from detailStore. (d) Add 'researchChanged' to the FileEvent type union and add a handler arm in the tiki-file-changed listener that calls invoke('list_research_docs', ...) and updates researchStore. (e) Add ResearchDetail to the detail panel chain: when selectedResearchDoc is non-null, render <ResearchDetail filename={selectedResearchDoc} projectPath={activeProject?.path} />.\n\n2. apps/desktop/src/stores/index.ts: Export useResearchStore and ResearchDocMeta from researchStore.\n\n3. Mirror sync: Copy updated framework command files to their mirror locations in packages/framework/.claude/commands/tiki/: research.md (new), review.md, plan.md, execute.md. The mirrors are byte-for-byte copies. Investigate install.js to see if it auto-syncs; if not, copy manually.\n\n4. Final verification: pnpm build from repo root (uses tsc -b, stricter than tsc --noEmit). cargo check in apps/desktop/src-tauri. Manual smoke test if Tauri dev environment is available: create a .tiki/research/test-topic.md with valid front-matter, confirm ResearchSection shows it, confirm clicking it opens ResearchDetail with rendered markdown.",
+      "verification": [
+        "App.tsx imports and mounts ResearchSection in the sidebar",
+        "App.tsx handles researchChanged file event by refreshing researchStore",
+        "App.tsx renders ResearchDetail in the detail panel when selectedResearchDoc is non-null",
+        "stores/index.ts exports useResearchStore and ResearchDocMeta",
+        "packages/framework/.claude/commands/tiki/research.md exists and matches packages/framework/commands/research.md",
+        "packages/framework/.claude/commands/tiki/review.md, plan.md, execute.md match their source files",
+        "pnpm build from repo root passes with no TypeScript or compilation errors",
+        "cargo check in apps/desktop/src-tauri passes"
+      ],
+      "addressesCriteria": ["SC11"],
+      "files": [
+        "apps/desktop/src/App.tsx",
+        "apps/desktop/src/stores/index.ts",
+        "packages/framework/.claude/commands/tiki/research.md",
+        "packages/framework/.claude/commands/tiki/review.md",
+        "packages/framework/.claude/commands/tiki/plan.md",
+        "packages/framework/.claude/commands/tiki/execute.md"
+      ],
+      "dependencies": [6]
+    }
+  ],
+  "coverageMatrix": {
+    "SC1": [1],
+    "SC2": [1],
+    "SC3": [2],
+    "SC4": [2],
+    "SC5": [3],
+    "SC6": [3],
+    "SC7": [4],
+    "SC8": [4],
+    "SC9": [5],
+    "SC10": [6],
+    "SC11": [7]
+  }
+}

--- a/.tiki/research/example-research.md
+++ b/.tiki/research/example-research.md
@@ -1,0 +1,21 @@
+---
+topic: github-api
+tags: [github, api, integration]
+issues: []
+created: 2026-05-08T00:00:00.000Z
+---
+
+# GitHub API access in Tiki V2
+
+Tiki V2 talks to GitHub exclusively through the `gh` CLI rather than the REST/GraphQL APIs directly. This avoids managing tokens in the framework code and reuses whatever authentication the user has already set up.
+
+## Common patterns
+
+- **Fetching an issue:** `gh issue view <N> --json number,title,body,state,labels,milestone,assignees,url,createdAt,updatedAt`. The `--json` flag returns a stable JSON shape that the framework commands parse directly.
+- **Auth check:** `gh auth status` is run defensively at the start of any command that hits GitHub. If it fails, surface the `no-gh-cli` error rather than letting the underlying call fail with a less helpful message.
+- **PR creation:** `gh pr create --title "..." --body "..."` from within the worktree; the active branch is used as the PR source.
+
+## Gotchas
+
+- On Windows, paths inside `gh` invocations should be quoted; the framework wraps them in double quotes when constructing commands from the Bash tool.
+- `gh issue view` returns the issue body with `\r\n` line endings on Windows — strip them before parsing markdown.

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::fs_utils::{self, BackupInfo};
 use crate::state::{TikiPlan, TikiRelease, TikiState, WorkContext, WorkStatus};
 use crate::watcher;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::path::PathBuf;
 use tauri_plugin_dialog::DialogExt;
@@ -13,6 +13,16 @@ pub enum WorkAction {
     Pause,
     Reset,
     Remove,
+}
+
+/// Metadata for a research doc parsed from its YAML front-matter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResearchDocMeta {
+    pub filename: String,
+    pub topic: String,
+    pub tags: Vec<String>,
+    pub issues: Vec<u32>,
+    pub created: String,
 }
 
 /// Mutate state.json for a single work entry: pause it, reset it to pending,
@@ -294,6 +304,174 @@ pub fn delete_tiki_release(version: String, tiki_path: Option<String>) -> Result
     }
 
     Ok(())
+}
+
+/// List all research docs in `.tiki/research/` with metadata parsed from their
+/// YAML front-matter. Returns an empty Vec if the directory doesn't exist —
+/// research is an optional Tiki feature.
+///
+/// Uses a simple line-based YAML parser rather than pulling in `serde_yaml`
+/// because the front-matter shape is fixed and tiny.
+#[tauri::command]
+pub fn list_research_docs(tiki_path: Option<String>) -> Result<Vec<ResearchDocMeta>, String> {
+    let path = resolve_tiki_path(tiki_path)?;
+    let research_dir = path.join("research");
+
+    if !research_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut docs = Vec::new();
+    let entries = std::fs::read_dir(&research_dir).map_err(|e| e.to_string())?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let file_path = entry.path();
+
+        if !file_path.extension().map_or(false, |ext| ext == "md") {
+            continue;
+        }
+
+        let filename = match file_path.file_name() {
+            Some(n) => n.to_string_lossy().to_string(),
+            None => continue,
+        };
+
+        let content = match std::fs::read_to_string(&file_path) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("Failed to read research doc {:?}: {}", file_path, e);
+                continue;
+            }
+        };
+
+        match parse_research_front_matter(&filename, &content) {
+            Some(meta) => docs.push(meta),
+            None => {
+                log::warn!("Skipping research doc with no front-matter: {}", filename);
+            }
+        }
+    }
+
+    // Sort by created descending (ISO 8601 strings sort chronologically).
+    docs.sort_by(|a, b| b.created.cmp(&a.created));
+
+    Ok(docs)
+}
+
+/// Read the raw contents of a single research doc.
+///
+/// Validates the filename to prevent path traversal: must end in `.md` and
+/// must not contain path separators or parent-dir components.
+#[tauri::command]
+pub fn read_research_doc(
+    filename: String,
+    tiki_path: Option<String>,
+) -> Result<String, String> {
+    if !filename.ends_with(".md")
+        || filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains("..")
+    {
+        return Err("invalid filename".to_string());
+    }
+
+    let path = resolve_tiki_path(tiki_path)?;
+    let file_path = path.join("research").join(&filename);
+
+    if !file_path.exists() {
+        return Err("file not found".to_string());
+    }
+
+    std::fs::read_to_string(&file_path).map_err(|e| e.to_string())
+}
+
+/// Parse the YAML front-matter from a research doc. Returns None if the file
+/// has no front-matter block. Missing fields are filled with sensible defaults
+/// and a warning is logged.
+fn parse_research_front_matter(filename: &str, content: &str) -> Option<ResearchDocMeta> {
+    let mut lines = content.lines();
+
+    // First non-empty content must be the opening `---`.
+    let opener = lines.next()?;
+    if opener.trim() != "---" {
+        return None;
+    }
+
+    let mut topic: Option<String> = None;
+    let mut created: Option<String> = None;
+    let mut tags: Vec<String> = Vec::new();
+    let mut issues: Vec<u32> = Vec::new();
+    let mut found_close = false;
+
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            found_close = true;
+            break;
+        }
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let (key, value) = match trimmed.split_once(':') {
+            Some((k, v)) => (k.trim(), v.trim()),
+            None => continue,
+        };
+
+        match key {
+            "topic" => topic = Some(value.trim_matches('"').trim_matches('\'').to_string()),
+            "created" => created = Some(value.trim_matches('"').trim_matches('\'').to_string()),
+            "tags" => {
+                tags = parse_yaml_list(value);
+            }
+            "issues" => {
+                issues = parse_yaml_list(value)
+                    .into_iter()
+                    .filter_map(|s| s.parse::<u32>().ok())
+                    .collect();
+            }
+            _ => {}
+        }
+    }
+
+    if !found_close {
+        return None;
+    }
+
+    let topic = topic.unwrap_or_else(|| {
+        log::warn!("Research doc {} missing 'topic' front-matter", filename);
+        filename.strip_suffix(".md").unwrap_or(filename).to_string()
+    });
+    let created = created.unwrap_or_else(|| {
+        log::warn!("Research doc {} missing 'created' front-matter", filename);
+        String::new()
+    });
+
+    Some(ResearchDocMeta {
+        filename: filename.to_string(),
+        topic,
+        tags,
+        issues,
+        created,
+    })
+}
+
+/// Parse a YAML inline list `[a, b, c]` into trimmed string items. Returns an
+/// empty Vec if the value isn't a bracketed list (we don't support block-form
+/// lists since the front-matter spec uses inline form).
+fn parse_yaml_list(value: &str) -> Vec<String> {
+    let trimmed = value.trim();
+    let inner = match trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+
+    inner
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 /// Back up state.json before a destructive operation

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -55,6 +55,8 @@ pub fn run() {
             commands::restore_backup,
             commands::update_work_status,
             commands::save_plan,
+            commands::list_research_docs,
+            commands::read_research_doc,
             github::check_claude_cli,
             github::check_gh_auth,
             github::fetch_github_issues,

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -56,6 +56,7 @@ pub enum TikiFileEvent {
     StateChanged,
     PlanChanged { issue_number: u32 },
     ReleaseChanged { version: String },
+    ResearchChanged { filename: String },
 }
 
 /// Start watching the .tiki directory for changes (initial startup)
@@ -172,6 +173,7 @@ fn debounce_key(file_event: &TikiFileEvent) -> String {
         TikiFileEvent::StateChanged => "state".to_string(),
         TikiFileEvent::PlanChanged { issue_number } => format!("plan-{}", issue_number),
         TikiFileEvent::ReleaseChanged { version } => format!("release-{}", version),
+        TikiFileEvent::ResearchChanged { filename } => format!("research-{}", filename),
     }
 }
 
@@ -240,6 +242,13 @@ fn process_event(event: &Event) -> Option<TikiFileEvent> {
                     });
                 }
             }
+
+            // Check for research docs (.tiki/research/*.md)
+            if let Some(research_filename) = is_in_research_dir(path) {
+                return Some(TikiFileEvent::ResearchChanged {
+                    filename: research_filename.to_string(),
+                });
+            }
         }
     }
 
@@ -249,6 +258,21 @@ fn process_event(event: &Event) -> Option<TikiFileEvent> {
 /// Check if a path is inside the releases directory
 fn is_in_releases_dir(path: &Path) -> bool {
     path.components().any(|c| c.as_os_str() == "releases")
+}
+
+/// Check if a path is inside the research directory and is a markdown file.
+/// Returns the filename (e.g. "auth-flow.md") if so, otherwise None.
+fn is_in_research_dir(path: &Path) -> Option<&str> {
+    let in_research = path.components().any(|c| c.as_os_str() == "research");
+    if !in_research {
+        return None;
+    }
+    let name = path.file_name()?.to_str()?;
+    if name.ends_with(".md") {
+        Some(name)
+    } else {
+        None
+    }
 }
 
 /// Check if a path is inside the backups directory

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -8,10 +8,11 @@ import { ProjectsSection } from "./components/sidebar/ProjectsSection";
 import { IssuesSection } from "./components/sidebar/IssuesSection";
 import { PullRequestsSection } from "./components/sidebar/PullRequestsSection";
 import { ReleasesSection } from "./components/sidebar/ReleasesSection";
+import { ResearchSection } from "./components/sidebar/ResearchSection";
 import { StateSection } from "./components/sidebar/StateSection";
 import { ClaudeUsageSection } from "./components/sidebar/ClaudeUsageSection";
 import { TerminalPane } from "./components/terminal";
-import { IssueDetail, PullRequestDetail, ReleaseDetail, TikiReleaseDetail } from "./components/detail";
+import { IssueDetail, PullRequestDetail, ReleaseDetail, ResearchDetail, TikiReleaseDetail } from "./components/detail";
 import { CenterTabs } from "./components/layout/CenterTabs";
 import { KanbanBoard } from "./components/kanban";
 import { DependencyGraph } from "./components/dependencies/DependencyGraph";
@@ -20,8 +21,8 @@ import { ToastContainer } from "./components/ui/ToastContainer";
 import { CommandPalette, KeyboardShortcuts } from "./components/ui";
 import { useCommandActions, useStaleWorkDetection } from "./hooks";
 import type { WorkContext } from "./components/work";
-import { useLayoutStore, useDetailStore, useIssuesStore, useReleasesStore, useProjectsStore, useTikiReleasesStore, useTikiStateStore, useTerminalStore, useToastStore, usePullRequestsStore, useCommandPaletteStore, useSettingsStore } from "./stores";
-import type { GitHubIssue, TikiRelease } from "./stores";
+import { useLayoutStore, useDetailStore, useIssuesStore, useReleasesStore, useProjectsStore, useTikiReleasesStore, useTikiStateStore, useTerminalStore, useToastStore, usePullRequestsStore, useCommandPaletteStore, useResearchStore, useSettingsStore } from "./stores";
+import type { GitHubIssue, ResearchDocMeta, TikiRelease } from "./stores";
 import { terminalFocusRegistry } from "./stores/terminalStore";
 import "./App.css";
 import "./components/layout/layout.css";
@@ -39,9 +40,10 @@ interface TikiState {
 }
 
 interface FileEvent {
-  type: "stateChanged" | "planChanged" | "releaseChanged";
+  type: "stateChanged" | "planChanged" | "releaseChanged" | "researchChanged";
   issueNumber?: number;
   version?: string;
+  filename?: string;
 }
 
 function detectStateChanges(
@@ -141,6 +143,7 @@ function App() {
   const selectedRelease = useDetailStore((s) => s.selectionByProject[activeProjectId]?.selectedRelease ?? null);
   const selectedTikiRelease = useDetailStore((s) => s.selectionByProject[activeProjectId]?.selectedTikiRelease ?? null);
   const selectedPr = useDetailStore((s) => s.selectionByProject[activeProjectId]?.selectedPr ?? null);
+  const selectedResearchDoc = useDetailStore((s) => s.selectionByProject[activeProjectId]?.selectedResearchDoc ?? null);
   const issues = useIssuesStore((s) => s.issues);
   const releases = useReleasesStore((s) => s.releases);
   const tikiReleases = useTikiReleasesStore((s) => s.releases);
@@ -275,6 +278,14 @@ function App() {
         } catch (e) {
           console.error("Failed to reload releases:", e);
         }
+      } else if (event.payload.type === "researchChanged") {
+        try {
+          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
+          const loadedDocs = await invoke<ResearchDocMeta[]>("list_research_docs", { tikiPath: projectTikiPath });
+          useResearchStore.getState().setDocs(loadedDocs);
+        } catch (e) {
+          console.error("Failed to reload research docs:", e);
+        }
       }
     });
 
@@ -374,6 +385,7 @@ function App() {
               <IssuesSection />
               <PullRequestsSection />
               <ReleasesSection />
+              <ResearchSection />
               <ClaudeUsageSection />
             </div>
             <div className="sidebar-footer">
@@ -471,6 +483,8 @@ function App() {
               <ReleaseDetail release={selectedReleaseData} />
             ) : selectedTikiReleaseData ? (
               <TikiReleaseDetail release={selectedTikiReleaseData} />
+            ) : selectedResearchDoc ? (
+              <ResearchDetail filename={selectedResearchDoc} projectPath={activeProject?.path} />
             ) : (
               <>
                 <h3>Detail</h3>

--- a/apps/desktop/src/components/detail/ResearchDetail.css
+++ b/apps/desktop/src/components/detail/ResearchDetail.css
@@ -1,0 +1,104 @@
+.research-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 16px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border-color, #3c3c3c);
+}
+
+.research-detail-topic {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-primary, #cccccc);
+  word-break: break-word;
+}
+
+.research-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.research-detail-tag {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background-color: rgba(128, 128, 128, 0.2);
+  color: var(--text-secondary, #858585);
+}
+
+.research-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.research-detail-date {
+  font-size: 12px;
+  color: var(--text-secondary, #858585);
+}
+
+.research-detail-issues {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.research-detail-issue {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background-color: rgba(0, 122, 204, 0.15);
+  color: #58a6ff;
+  font-family: var(--font-mono, monospace);
+}
+
+.research-detail-body {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-primary, #cccccc);
+}
+
+.research-detail-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 32px 16px;
+  color: var(--text-secondary, #858585);
+  font-size: 13px;
+}
+
+@keyframes research-detail-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.research-detail-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border-color, #3c3c3c);
+  border-top-color: var(--accent-color, #007acc);
+  border-radius: 50%;
+  animation: research-detail-spin 0.8s linear infinite;
+}
+
+.research-detail-error {
+  margin: 16px;
+  padding: 12px 14px;
+  background-color: var(--error-bg, #5a1d1d);
+  border: 1px solid var(--error-border, #be1100);
+  border-radius: 6px;
+  color: var(--error-text, #f48771);
+  font-size: 13px;
+  line-height: 1.4;
+}

--- a/apps/desktop/src/components/detail/ResearchDetail.tsx
+++ b/apps/desktop/src/components/detail/ResearchDetail.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+import "./ResearchDetail.css";
+
+interface ResearchDetailProps {
+  filename: string;
+  projectPath: string | undefined;
+}
+
+interface FrontMatter {
+  topic: string;
+  tags: string[];
+  issues: number[];
+  created: string;
+}
+
+interface ParsedDoc {
+  frontMatter: FrontMatter;
+  body: string;
+}
+
+/** Parse a YAML-ish front-matter scalar that may be a JSON-style array or comma-separated. */
+function parseListValue(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "[]") return [];
+
+  // JSON-style array: [a, b, c] or ["a", "b"]
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (inner === "") return [];
+    return inner
+      .split(",")
+      .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+      .filter((s) => s.length > 0);
+  }
+
+  // Comma-separated fallback
+  return trimmed
+    .split(",")
+    .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+    .filter((s) => s.length > 0);
+}
+
+function parseScalar(raw: string): string {
+  return raw.trim().replace(/^["']|["']$/g, "");
+}
+
+function parseFrontMatter(raw: string): ParsedDoc {
+  // Locate opening --- and closing ---
+  const lines = raw.split(/\r?\n/);
+  if (lines.length === 0 || lines[0].trim() !== "---") {
+    return {
+      frontMatter: { topic: "", tags: [], issues: [], created: "" },
+      body: raw,
+    };
+  }
+
+  let endIndex = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      endIndex = i;
+      break;
+    }
+  }
+
+  if (endIndex === -1) {
+    return {
+      frontMatter: { topic: "", tags: [], issues: [], created: "" },
+      body: raw,
+    };
+  }
+
+  const fmLines = lines.slice(1, endIndex);
+  const bodyLines = lines.slice(endIndex + 1);
+
+  const fm: FrontMatter = { topic: "", tags: [], issues: [], created: "" };
+
+  for (const line of fmLines) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1);
+
+    switch (key) {
+      case "topic":
+        fm.topic = parseScalar(value);
+        break;
+      case "tags":
+        fm.tags = parseListValue(value);
+        break;
+      case "issues":
+        fm.issues = parseListValue(value)
+          .map((s) => Number(s))
+          .filter((n) => !isNaN(n));
+        break;
+      case "created":
+        fm.created = parseScalar(value);
+        break;
+    }
+  }
+
+  // Body: drop leading blank lines for cleaner rendering
+  let bodyStart = 0;
+  while (bodyStart < bodyLines.length && bodyLines[bodyStart].trim() === "") {
+    bodyStart++;
+  }
+  const body = bodyLines.slice(bodyStart).join("\n");
+
+  return { frontMatter: fm, body };
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso.length >= 10 ? iso.slice(0, 10) : iso;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function ResearchDetail({ filename, projectPath }: ResearchDetailProps) {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    setContent(null);
+
+    const tikiPath = projectPath ? `${projectPath}/.tiki` : undefined;
+
+    invoke<string>("read_research_doc", { filename, tikiPath })
+      .then((raw) => {
+        if (cancelled) return;
+        setContent(raw);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(String(err));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filename, projectPath]);
+
+  if (isLoading) {
+    return (
+      <div className="research-detail-loading">
+        <span className="research-detail-spinner" />
+        Loading research...
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="research-detail-error">{error}</div>;
+  }
+
+  if (content === null) {
+    return null;
+  }
+
+  const { frontMatter, body } = parseFrontMatter(content);
+  const displayTopic = frontMatter.topic || filename;
+
+  return (
+    <div className="detail-view">
+      <div className="research-detail-header">
+        <h2 className="research-detail-topic">{displayTopic}</h2>
+        {frontMatter.tags.length > 0 && (
+          <div className="research-detail-tags">
+            {frontMatter.tags.map((tag) => (
+              <span key={tag} className="research-detail-tag">
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="research-detail-meta">
+          {frontMatter.created && (
+            <span className="research-detail-date">{formatDate(frontMatter.created)}</span>
+          )}
+          {frontMatter.issues.length > 0 && (
+            <div className="research-detail-issues">
+              {frontMatter.issues.map((n) => (
+                <span key={n} className="research-detail-issue">#{n}</span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="research-detail-body markdown-body">
+        <MarkdownRenderer>{body}</MarkdownRenderer>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/detail/index.ts
+++ b/apps/desktop/src/components/detail/index.ts
@@ -2,3 +2,4 @@ export { IssueDetail } from './IssueDetail';
 export { PullRequestDetail } from './PullRequestDetail';
 export { ReleaseDetail } from './ReleaseDetail';
 export { TikiReleaseDetail } from './TikiReleaseDetail';
+export { ResearchDetail } from './ResearchDetail';

--- a/apps/desktop/src/components/sidebar/ResearchSection.css
+++ b/apps/desktop/src/components/sidebar/ResearchSection.css
@@ -1,0 +1,151 @@
+.research-section-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.research-section-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.research-section-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  background: var(--bg-secondary, #1e1e1e);
+  border: 1px solid var(--border-color, #3c3c3c);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.research-section-card:hover {
+  border-color: var(--accent-color, #007acc);
+  background-color: var(--bg-hover, #2a2a2a);
+}
+
+.research-section-card:focus {
+  outline: none;
+  border-color: var(--accent-color, #007acc);
+}
+
+.research-section-card.selected {
+  border-color: var(--accent-color, #007acc);
+  background-color: rgba(0, 122, 204, 0.1);
+}
+
+.research-section-topic {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary, #cccccc);
+  word-break: break-word;
+}
+
+.research-section-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.research-section-tag {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background-color: rgba(128, 128, 128, 0.2);
+  color: var(--text-secondary, #858585);
+}
+
+.research-section-date {
+  font-size: 11px;
+  color: var(--text-secondary, #858585);
+}
+
+.research-section-empty {
+  padding: 12px 10px;
+  color: var(--text-secondary, #858585);
+  font-size: 12px;
+  text-align: center;
+  font-style: italic;
+}
+
+.research-section-empty code {
+  background: rgba(128, 128, 128, 0.15);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-family: var(--font-mono, monospace);
+  font-style: normal;
+  font-size: 11px;
+}
+
+.research-section-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 16px 10px;
+  color: var(--text-secondary, #858585);
+  font-size: 12px;
+}
+
+@keyframes research-section-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.research-section-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border-color, #3c3c3c);
+  border-top-color: var(--accent-color, #007acc);
+  border-radius: 50%;
+  animation: research-section-spin 0.8s linear infinite;
+}
+
+.research-section-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  background-color: var(--error-bg, #5a1d1d);
+  border: 1px solid var(--error-border, #be1100);
+  border-radius: 6px;
+  color: var(--error-text, #f48771);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.research-section-error span {
+  flex: 1;
+}
+
+.research-section-error-dismiss {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: none;
+  background: transparent;
+  color: var(--error-text, #f48771);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s ease;
+  flex-shrink: 0;
+}
+
+.research-section-error-dismiss:hover {
+  opacity: 1;
+}

--- a/apps/desktop/src/components/sidebar/ResearchSection.tsx
+++ b/apps/desktop/src/components/sidebar/ResearchSection.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { CollapsibleSection } from "../ui/CollapsibleSection";
+import { useProjectsStore, useDetailStore } from "../../stores";
+import { useResearchStore, type ResearchDocMeta } from "../../stores/researchStore";
+import "./ResearchSection.css";
+
+/** Format an ISO date string into a relative or short representation. */
+function formatRelativeDate(iso: string): string {
+  const created = new Date(iso);
+  if (isNaN(created.getTime())) {
+    // Fallback: take the YYYY-MM-DD prefix if present
+    return iso.length >= 10 ? iso.slice(0, 10) : iso;
+  }
+  const now = new Date();
+  const diffMs = now.getTime() - created.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHr = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHr / 24);
+
+  if (diffSec < 60) return "just now";
+  if (diffMin < 60) return `${diffMin} minute${diffMin !== 1 ? "s" : ""} ago`;
+  if (diffHr < 24) return `${diffHr} hour${diffHr !== 1 ? "s" : ""} ago`;
+  if (diffDay < 30) return `${diffDay} day${diffDay !== 1 ? "s" : ""} ago`;
+  // Older: show YYYY-MM-DD
+  const y = created.getFullYear();
+  const m = String(created.getMonth() + 1).padStart(2, "0");
+  const d = String(created.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function ResearchSection() {
+  const docs = useResearchStore((state) => state.docs);
+  const isLoading = useResearchStore((state) => state.isLoading);
+  const error = useResearchStore((state) => state.error);
+  const setDocs = useResearchStore((state) => state.setDocs);
+  const setLoading = useResearchStore((state) => state.setLoading);
+  const setError = useResearchStore((state) => state.setError);
+  const clearError = useResearchStore((state) => state.clearError);
+
+  const activeProject = useProjectsStore((state) =>
+    state.projects.find((p) => p.id === state.activeProjectId)
+  );
+
+  const projectId = useProjectsStore((state) => state.activeProjectId) ?? "default";
+  const selectedResearchDoc = useDetailStore(
+    (state) => state.selectionByProject[projectId]?.selectedResearchDoc ?? null
+  );
+  const setSelectedResearchDoc = useDetailStore((state) => state.setSelectedResearchDoc);
+
+  const loadResearchDocs = useCallback(async () => {
+    if (!activeProject) {
+      setDocs([]);
+      clearError();
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    clearError();
+
+    try {
+      const tikiPath = `${activeProject.path}/.tiki`;
+      const loaded = await invoke<ResearchDocMeta[]>("list_research_docs", { tikiPath });
+      setDocs(loaded);
+    } catch (err) {
+      setError(String(err));
+      setDocs([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [activeProject, setDocs, setLoading, setError, clearError]);
+
+  useEffect(() => {
+    loadResearchDocs();
+  }, [loadResearchDocs]);
+
+  const researchIcon = (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 2H10C11.1046 2 12 2.89543 12 4V14L8 12L4 14V4C4 2.89543 4.89543 2 3 2Z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      <path
+        d="M3 2H4V14"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6 6H10M6 9H9"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+
+  const hasProject = !!activeProject;
+  const totalCount = docs.length;
+
+  return (
+    <CollapsibleSection
+      title="Research"
+      icon={researchIcon}
+      badge={totalCount > 0 ? totalCount : undefined}
+      className="research-section"
+    >
+      <div className="research-section-content">
+        {error && (
+          <div className="research-section-error">
+            <span>{error}</span>
+            <button
+              className="research-section-error-dismiss"
+              onClick={clearError}
+              type="button"
+              aria-label="Dismiss error"
+            >
+              &times;
+            </button>
+          </div>
+        )}
+
+        {isLoading && docs.length === 0 && (
+          <div className="research-section-loading">
+            <span className="research-section-spinner" />
+            Loading...
+          </div>
+        )}
+
+        {docs.length > 0 && (
+          <div className="research-section-list">
+            {docs.map((doc) => {
+              const isSelected = selectedResearchDoc === doc.filename;
+              return (
+                <div
+                  key={doc.filename}
+                  className={`research-section-card${isSelected ? " selected" : ""}`}
+                  onClick={() => setSelectedResearchDoc(doc.filename)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelectedResearchDoc(doc.filename);
+                    }
+                  }}
+                  tabIndex={0}
+                  role="button"
+                >
+                  <div className="research-section-topic">{doc.topic}</div>
+                  {doc.tags.length > 0 && (
+                    <div className="research-section-tags">
+                      {doc.tags.map((tag) => (
+                        <span key={tag} className="research-section-tag">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  <div className="research-section-date">{formatRelativeDate(doc.created)}</div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {!hasProject && docs.length === 0 && !isLoading && (
+          <div className="research-section-empty">
+            Select a project to view research docs
+          </div>
+        )}
+
+        {hasProject && !isLoading && !error && docs.length === 0 && (
+          <div className="research-section-empty">
+            No research docs yet. Use <code>/tiki:research &lt;topic&gt;</code> to capture knowledge.
+          </div>
+        )}
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/apps/desktop/src/stores/detailStore.ts
+++ b/apps/desktop/src/stores/detailStore.ts
@@ -7,6 +7,7 @@ interface ProjectSelection {
   selectedRelease: string | null;
   selectedTikiRelease: string | null;
   selectedPr: number | null;
+  selectedResearchDoc: string | null;
 }
 
 interface DetailState {
@@ -18,6 +19,7 @@ interface DetailActions {
   setSelectedRelease: (tagName: string | null) => void;
   setSelectedTikiRelease: (version: string | null) => void;
   setSelectedPr: (prNumber: number | null) => void;
+  setSelectedResearchDoc: (filename: string | null) => void;
   clearSelection: () => void;
   cleanupProject: (projectId: string) => void;
 }
@@ -33,6 +35,7 @@ const emptySelection: ProjectSelection = {
   selectedRelease: null,
   selectedTikiRelease: null,
   selectedPr: null,
+  selectedResearchDoc: null,
 };
 
 const initialState: DetailState = {
@@ -54,6 +57,7 @@ export const useDetailStore = create<DetailStore>()(
               selectedRelease: null,
               selectedTikiRelease: null,
               selectedPr: null,
+              selectedResearchDoc: null,
             },
           },
         }));
@@ -69,6 +73,7 @@ export const useDetailStore = create<DetailStore>()(
               selectedIssue: null,
               selectedTikiRelease: null,
               selectedPr: null,
+              selectedResearchDoc: null,
             },
           },
         }));
@@ -84,6 +89,7 @@ export const useDetailStore = create<DetailStore>()(
               selectedIssue: null,
               selectedRelease: null,
               selectedPr: null,
+              selectedResearchDoc: null,
             },
           },
         }));
@@ -99,6 +105,23 @@ export const useDetailStore = create<DetailStore>()(
               selectedIssue: null,
               selectedRelease: null,
               selectedTikiRelease: null,
+              selectedResearchDoc: null,
+            },
+          },
+        }));
+      },
+
+      setSelectedResearchDoc: (filename) => {
+        const projectId = getProjectId();
+        set((state) => ({
+          selectionByProject: {
+            ...state.selectionByProject,
+            [projectId]: {
+              selectedResearchDoc: filename,
+              selectedIssue: null,
+              selectedRelease: null,
+              selectedTikiRelease: null,
+              selectedPr: null,
             },
           },
         }));

--- a/apps/desktop/src/stores/index.ts
+++ b/apps/desktop/src/stores/index.ts
@@ -37,6 +37,11 @@ export {
 export { useDetailStore } from './detailStore';
 
 export {
+  useResearchStore,
+  type ResearchDocMeta,
+} from './researchStore';
+
+export {
   useTikiReleasesStore,
   type TikiRelease,
   type TikiReleaseIssue,

--- a/apps/desktop/src/stores/researchStore.ts
+++ b/apps/desktop/src/stores/researchStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+
+export interface ResearchDocMeta {
+  filename: string;
+  topic: string;
+  tags: string[];
+  issues: number[];
+  created: string;
+}
+
+interface ResearchState {
+  docs: ResearchDocMeta[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+interface ResearchActions {
+  setDocs: (docs: ResearchDocMeta[]) => void;
+  setLoading: (loading: boolean) => void;
+  setError: (error: string | null) => void;
+  clearError: () => void;
+}
+
+type ResearchStore = ResearchState & ResearchActions;
+
+const initialState: ResearchState = {
+  docs: [],
+  isLoading: false,
+  error: null,
+};
+
+export const useResearchStore = create<ResearchStore>()((set) => ({
+  ...initialState,
+
+  setDocs: (docs) => set({ docs }),
+
+  setLoading: (isLoading) => set({ isLoading }),
+
+  setError: (error) => set({ error }),
+
+  clearError: () => set({ error: null }),
+}));

--- a/packages/framework/.claude/commands/tiki/execute.md
+++ b/packages/framework/.claude/commands/tiki/execute.md
@@ -12,6 +12,7 @@ Execute the phases of a planned issue. Each phase runs with focused context, pro
 <instructions>
   <step>Load the plan from `.tiki/plans/issue-{number}.json`</step>
   <step>Load current state from `.tiki/state.json` to find current phase</step>
+  <step>**Retrieve relevant research** from `.tiki/research/` before dispatching any sub-agent (see `<research-retrieval>` below). Research content must be included in every sub-agent prompt under a `## Research Context` heading.</step>
   <step>**CRITICAL: Update state.json with phase info BEFORE starting work** (see state-update-requirement below)</step>
   <step>For the current phase:
     1. Display phase details (title, files, verification criteria)
@@ -23,6 +24,23 @@ Execute the phases of a planned issue. Each phase runs with focused context, pro
   <step>If verification passes, advance to next phase or complete</step>
   <step>If verification fails, offer recovery options</step>
 </instructions>
+
+<research-retrieval>
+**Before dispatching any sub-agent task, check `.tiki/research/` for relevant prior findings.** Sub-agents start with fresh context and rely on the parent prompt for any domain knowledge — research docs are the channel that carries hard-won learnings from REVIEW and PLAN into EXECUTE.
+
+Procedure:
+
+1. **List** files matching `.tiki/research/*.md` using the Glob tool. If the directory does not exist or is empty, **skip silently** — no error, no output.
+2. **Read the front-matter** of each file (just the YAML lines between the first two `---` delimiters). Extract `topic`, `tags`, and `issues`.
+3. **Determine relevance** for the current issue and phase. A doc is relevant if any of these are true:
+   - The doc's `issues` array contains the current issue number `{number}`.
+   - One or more of the doc's `tags` matches a label, file path, technology, or domain term from the issue or the current phase content.
+   - The `topic` slug clearly relates to the files this phase will touch.
+4. **Read the full body** of each relevant doc.
+5. **Surface findings** in a `## Research Context` section in the parent execute output before sub-agent dispatch.
+6. **Pass research content into every sub-agent prompt.** When constructing the Task prompt (see `<sub-agent-protocol>`), include a `## Research Context` heading near the top with the body of each relevant research doc (front-matter stripped). Sub-agents have no other way to see this content — if you do not pass it through, the knowledge is lost.
+7. If no relevant docs are found, omit the `## Research Context` section entirely (do not include an empty heading in the sub-agent prompt).
+</research-retrieval>
 
 <state-update-requirement>
 ## CRITICAL: Phase State Updates
@@ -115,6 +133,9 @@ Task tool parameters:
 - description: "Execute phase {N}: {title}"
 - prompt: |
     You are executing Phase {N} of Issue #{number}: {issue title}
+
+    ## Research Context
+    {bodies of relevant .tiki/research/*.md docs, front-matter stripped — omit this entire section if no relevant docs were found in <research-retrieval>}
 
     ## Previous Phase Summaries
     {summaries from phases 1 to N-1}

--- a/packages/framework/.claude/commands/tiki/plan.md
+++ b/packages/framework/.claude/commands/tiki/plan.md
@@ -17,6 +17,7 @@ Break a GitHub issue into a sequence of executable phases. Each phase should be 
     - If no review exists, perform a quick analysis first
   </step>
   <step>**Immediately** update `.tiki/state.json` to set `status: "planning"` and `pipelineStep: "PLAN"` so the issue appears in Active Work right away (see early-state-update below)</step>
+  <step>**Retrieve relevant research** from `.tiki/research/` before designing phases (see `<research-retrieval>` below). Surface findings under a `## Research Context` heading in the planning output.</step>
   <step>Design phases following the planning principles below</step>
   <step>For each phase, define:
     - Clear title and description
@@ -29,6 +30,25 @@ Break a GitHub issue into a sequence of executable phases. Each phase should be 
   <step>Write the plan to `.tiki/plans/issue-{number}.json`</step>
   <step>Present the plan summary and ask for approval</step>
 </instructions>
+
+<research-retrieval>
+**Before designing phases, check `.tiki/research/` for relevant prior findings.** This step grounds planning in knowledge captured by earlier `/tiki:review`, `/tiki:plan`, and `/tiki:research` runs.
+
+Procedure:
+
+1. **List** files matching `.tiki/research/*.md` using the Glob tool. If the directory does not exist or is empty, **skip silently** — no error, no output.
+2. **Read the front-matter** of each file (just the YAML lines between the first two `---` delimiters — you do not need the body yet). Extract `topic`, `tags`, and `issues`.
+3. **Determine relevance** for the current issue. A doc is relevant if any of these are true:
+   - The doc's `issues` array contains the current issue number `{number}`.
+   - The doc's `issues` array contains an issue number that is referenced in this issue's body or labels (e.g. "depends on #87").
+   - One or more of the doc's `tags` matches a label, file path, technology, or domain term from the issue.
+   - The `topic` slug clearly relates to the issue's subject matter.
+4. **Read the full body** of each relevant doc.
+5. **Surface findings** in a `## Research Context` block in the planning output, before phase design begins. List each relevant doc by topic with a 1-2 sentence takeaway, and quote any constraint that should shape phase boundaries.
+6. **Use the findings** when defining phases — especially to avoid re-discovering known constraints, to honor existing patterns, and to set realistic verification criteria.
+
+If no relevant docs are found, proceed without a Research Context block (do not output an empty heading).
+</research-retrieval>
 
 <planning-principles>
 **Phase Size:**
@@ -113,6 +133,32 @@ For each phase, capture:
 
 *Plan written to `.tiki/plans/issue-{number}.json`*
 </output>
+
+<research-capture>
+**As a side-effect of PLAN, capture planning-relevant constraints discovered while designing phases.**
+
+While exploring the codebase to design phase boundaries, you likely uncovered constraints that future plans (or future runs of this same plan) will benefit from — phase ordering rules, build-step dependencies, schema migration gotchas, framework command mirror requirements, "this must happen before that" knowledge, etc. Persist these by writing one or more research docs to `.tiki/research/<topic>.md`.
+
+Each research doc uses this YAML front-matter schema, then a free-form markdown body:
+
+```yaml
+---
+topic: <kebab-case-slug>
+tags: [tag1, tag2, tag3]
+issues: [{number}]
+created: <ISO 8601 timestamp>
+---
+```
+
+Rules:
+1. **Topic slug** is kebab-case derived from the constraint or pattern (e.g. `mirror-sync`, `phase-ordering`, `cargo-check-windows`).
+2. **Tags** are 2-5 short lowercase strings reflecting the categorization (planning, build, schema, etc.).
+3. **Issues** array includes the current issue number `[{number}]`.
+4. **Created** is the current ISO 8601 timestamp.
+5. **Skip** writing if the plan was straightforward and surfaced no constraints worth preserving — a trivial 2-phase plan that just edits one component does not need a research doc. Quality > quantity.
+6. **Append, do not overwrite.** If `.tiki/research/<topic>.md` already exists, read it and append a new section under a `## YYYY-MM-DD findings` heading rather than replacing the file. Extend the front-matter `issues` array if the current issue is not already listed.
+7. Focus on **planning-relevant** knowledge here — REVIEW captures domain understanding, PLAN captures the constraints that shaped phase boundaries.
+</research-capture>
 
 <early-state-update>
 **Before doing any planning work**, update `.tiki/state.json` so the issue appears in Active Work immediately:

--- a/packages/framework/.claude/commands/tiki/research.md
+++ b/packages/framework/.claude/commands/tiki/research.md
@@ -1,0 +1,131 @@
+---
+name: research
+description: Capture domain knowledge or findings into a research document
+argument: <topic>
+tools: Bash, Read, Write, Glob, AskUserQuestion
+---
+
+# Research Topic
+
+Capture domain knowledge, architecture findings, API conventions, or any non-trivial learning into a `.tiki/research/<topic>.md` document. Research docs are surfaced automatically during planning and execution to give Claude (and sub-agents) the context they need.
+
+<instructions>
+  <step>Parse the arguments:
+    - First positional argument is the **topic slug** (required, kebab-case, e.g. `github-api`, `auth-flow`).
+    - Optional `--issue N` flag attaches the doc to a specific GitHub issue (sets the `issues` field to `[N]`).
+    - If no topic is provided, ask the user via AskUserQuestion (or surface the no-argument error below).
+  </step>
+  <step>Validate the topic slug:
+    - Must be lowercase kebab-case (letters, digits, hyphens only).
+    - Must not contain `/` or `..` (path-traversal guard).
+    - Surface the `invalid-topic-slug` error if it fails validation.
+  </step>
+  <step>Determine the body content:
+    - If content was piped in (e.g. via stdin or a prior message), use it verbatim.
+    - Otherwise, use the conversation context: Claude already knows what the user wants captured from prior messages, so write the doc directly.
+    - If the topic is genuinely ambiguous, ask the user a single clarifying question before writing.
+  </step>
+  <step>Infer tags:
+    - Pick 2-5 short tags reflecting the topic (e.g. `[github, api, integration]`, `[auth, security]`, `[tauri, ipc]`).
+    - If unclear, ask the user via AskUserQuestion.
+  </step>
+  <step>Check for an existing doc at `.tiki/research/<topic>.md`:
+    - If it exists, read it and present an AskUserQuestion offering **Merge** (append a new `## YYYY-MM-DD findings` section to the existing body, preserving the original front-matter — but extend `issues` and `tags` arrays with new values, and update `created` only if missing) vs. **Overwrite** (replace the file entirely) vs. **Cancel**.
+    - If it does not exist, proceed to write a fresh file.
+  </step>
+  <step>Write `.tiki/research/<topic>.md` with the front-matter schema below, then the markdown body. Create the `.tiki/research/` directory if it does not exist.</step>
+  <step>Confirm to the user with the path and a one-line summary.</step>
+</instructions>
+
+<front-matter-schema>
+Every research doc starts with this YAML front-matter block:
+
+```yaml
+---
+topic: <kebab-case-slug>
+tags: [tag1, tag2, tag3]
+issues: [42, 87]
+created: <ISO 8601 timestamp>
+---
+```
+
+Field rules:
+- `topic`: same as the filename slug (without `.md`).
+- `tags`: a JSON-style array of short lowercase strings.
+- `issues`: a JSON-style array of integer issue numbers. Empty (`[]`) if not tied to a specific issue.
+- `created`: ISO 8601 timestamp at write time, e.g. `2026-05-08T17:42:00.000Z`.
+
+After the closing `---` delimiter, the rest of the file is free-form markdown.
+</front-matter-schema>
+
+<output>
+## Research Captured: {topic}
+
+**File:** `.tiki/research/{topic}.md`
+**Tags:** {tag1, tag2, ...}
+**Issues:** {[N] or "none"}
+
+---
+
+{First ~80 chars of the body as a preview...}
+
+---
+
+*Research saved. It will surface automatically during `/tiki:plan` and `/tiki:execute` when relevant.*
+</output>
+
+<example-output>
+For `/tiki:research github-api --issue 102`:
+
+## Research Captured: github-api
+
+**File:** `.tiki/research/github-api.md`
+**Tags:** github, api, integration
+**Issues:** [102]
+
+---
+
+This codebase uses the `gh` CLI for all GitHub Issue and PR access. Auth is checked via `gh auth status`...
+
+---
+
+*Research saved. It will surface automatically during `/tiki:plan` and `/tiki:execute` when relevant.*
+</example-output>
+
+<errors>
+  <error type="no-argument">
+    No topic provided. Please specify a topic slug:
+    ```
+    /tiki:research github-api
+    /tiki:research auth-flow --issue 42
+    ```
+  </error>
+  <error type="invalid-topic-slug">
+    Topic slug "{topic}" is invalid. Must be lowercase kebab-case (letters, digits, hyphens only) and must not contain `/` or `..`. Examples: `github-api`, `auth-flow`, `tauri-ipc`.
+  </error>
+  <error type="write-failed">
+    Failed to write `.tiki/research/{topic}.md`: {error message}. Check that the working directory is writable and that `.tiki/` exists.
+  </error>
+</errors>
+
+<next-actions>
+After saving the research doc, offer these options:
+
+1. **Plan the linked issue** - Continue with planning (`/tiki:plan {N}`) — only if `--issue N` was given.
+2. **Capture another topic** - Run `/tiki:research <other-topic>` again.
+3. **View the doc** - Open the new file for review.
+4. **Done** - Return to the previous workflow step.
+
+Present using AskUserQuestion with:
+- question: "Research saved. What's next?"
+- header: "Next step"
+- options:
+  - label: "Plan linked issue"
+    description: "Continue with /tiki:plan for the attached issue"
+  - label: "Capture another topic"
+    description: "Run /tiki:research again with a different topic"
+  - label: "View the doc"
+    description: "Open the new research file"
+  - label: "Done"
+    description: "Return to the previous step"
+</next-actions>

--- a/packages/framework/.claude/commands/tiki/review.md
+++ b/packages/framework/.claude/commands/tiki/review.md
@@ -110,6 +110,32 @@ Prefix each with an ID: SC1, SC2, SC3, etc.
 *Review complete. Ready to plan.*
 </output>
 
+<research-capture>
+**As a side-effect of REVIEW, capture domain understanding from codebase exploration.**
+
+While analyzing the codebase to understand this issue, you likely uncovered non-trivial knowledge — architecture patterns, API conventions, hidden constraints, data models, important file conventions, auth flows, IPC contracts, etc. Persist anything that future planning or execution might need by writing one or more research docs to `.tiki/research/<topic>.md`.
+
+Each research doc uses this YAML front-matter schema, then a free-form markdown body:
+
+```yaml
+---
+topic: <kebab-case-slug>
+tags: [tag1, tag2, tag3]
+issues: [{number}]
+created: <ISO 8601 timestamp>
+---
+```
+
+Rules:
+1. **Topic slug** is kebab-case derived from the subject (e.g. `auth-flow`, `tauri-watcher`, `state-schema`).
+2. **Tags** are 2-5 short lowercase strings reflecting the categorization.
+3. **Issues** array includes the current issue number `[{number}]`.
+4. **Created** is the current ISO 8601 timestamp.
+5. **Skip** writing if the issue is purely a one-line bug fix or has no meaningful domain learning. Quality > quantity — do not pad output with shallow notes.
+6. **Append, do not overwrite.** If `.tiki/research/<topic>.md` already exists, read it and append a new section under a `## YYYY-MM-DD findings` heading rather than replacing the file. Extend the front-matter `issues` array if the current issue is not already listed.
+7. Multiple research docs are fine if findings span distinct topics — write one file per coherent topic rather than a single grab-bag.
+</research-capture>
+
 <state-management>
 Update `.tiki/state.json` after review:
 - Change status from `pending` to `reviewing`

--- a/packages/framework/commands/execute.md
+++ b/packages/framework/commands/execute.md
@@ -12,6 +12,7 @@ Execute the phases of a planned issue. Each phase runs with focused context, pro
 <instructions>
   <step>Load the plan from `.tiki/plans/issue-{number}.json`</step>
   <step>Load current state from `.tiki/state.json` to find current phase</step>
+  <step>**Retrieve relevant research** from `.tiki/research/` before dispatching any sub-agent (see `<research-retrieval>` below). Research content must be included in every sub-agent prompt under a `## Research Context` heading.</step>
   <step>**CRITICAL: Update state.json with phase info BEFORE starting work** (see state-update-requirement below)</step>
   <step>For the current phase:
     1. Display phase details (title, files, verification criteria)
@@ -23,6 +24,23 @@ Execute the phases of a planned issue. Each phase runs with focused context, pro
   <step>If verification passes, advance to next phase or complete</step>
   <step>If verification fails, offer recovery options</step>
 </instructions>
+
+<research-retrieval>
+**Before dispatching any sub-agent task, check `.tiki/research/` for relevant prior findings.** Sub-agents start with fresh context and rely on the parent prompt for any domain knowledge — research docs are the channel that carries hard-won learnings from REVIEW and PLAN into EXECUTE.
+
+Procedure:
+
+1. **List** files matching `.tiki/research/*.md` using the Glob tool. If the directory does not exist or is empty, **skip silently** — no error, no output.
+2. **Read the front-matter** of each file (just the YAML lines between the first two `---` delimiters). Extract `topic`, `tags`, and `issues`.
+3. **Determine relevance** for the current issue and phase. A doc is relevant if any of these are true:
+   - The doc's `issues` array contains the current issue number `{number}`.
+   - One or more of the doc's `tags` matches a label, file path, technology, or domain term from the issue or the current phase content.
+   - The `topic` slug clearly relates to the files this phase will touch.
+4. **Read the full body** of each relevant doc.
+5. **Surface findings** in a `## Research Context` section in the parent execute output before sub-agent dispatch.
+6. **Pass research content into every sub-agent prompt.** When constructing the Task prompt (see `<sub-agent-protocol>`), include a `## Research Context` heading near the top with the body of each relevant research doc (front-matter stripped). Sub-agents have no other way to see this content — if you do not pass it through, the knowledge is lost.
+7. If no relevant docs are found, omit the `## Research Context` section entirely (do not include an empty heading in the sub-agent prompt).
+</research-retrieval>
 
 <state-update-requirement>
 ## CRITICAL: Phase State Updates
@@ -115,6 +133,9 @@ Task tool parameters:
 - description: "Execute phase {N}: {title}"
 - prompt: |
     You are executing Phase {N} of Issue #{number}: {issue title}
+
+    ## Research Context
+    {bodies of relevant .tiki/research/*.md docs, front-matter stripped — omit this entire section if no relevant docs were found in <research-retrieval>}
 
     ## Previous Phase Summaries
     {summaries from phases 1 to N-1}

--- a/packages/framework/commands/plan.md
+++ b/packages/framework/commands/plan.md
@@ -17,6 +17,7 @@ Break a GitHub issue into a sequence of executable phases. Each phase should be 
     - If no review exists, perform a quick analysis first
   </step>
   <step>**Immediately** update `.tiki/state.json` to set `status: "planning"` and `pipelineStep: "PLAN"` so the issue appears in Active Work right away (see early-state-update below)</step>
+  <step>**Retrieve relevant research** from `.tiki/research/` before designing phases (see `<research-retrieval>` below). Surface findings under a `## Research Context` heading in the planning output.</step>
   <step>Design phases following the planning principles below</step>
   <step>For each phase, define:
     - Clear title and description
@@ -29,6 +30,25 @@ Break a GitHub issue into a sequence of executable phases. Each phase should be 
   <step>Write the plan to `.tiki/plans/issue-{number}.json`</step>
   <step>Present the plan summary and ask for approval</step>
 </instructions>
+
+<research-retrieval>
+**Before designing phases, check `.tiki/research/` for relevant prior findings.** This step grounds planning in knowledge captured by earlier `/tiki:review`, `/tiki:plan`, and `/tiki:research` runs.
+
+Procedure:
+
+1. **List** files matching `.tiki/research/*.md` using the Glob tool. If the directory does not exist or is empty, **skip silently** — no error, no output.
+2. **Read the front-matter** of each file (just the YAML lines between the first two `---` delimiters — you do not need the body yet). Extract `topic`, `tags`, and `issues`.
+3. **Determine relevance** for the current issue. A doc is relevant if any of these are true:
+   - The doc's `issues` array contains the current issue number `{number}`.
+   - The doc's `issues` array contains an issue number that is referenced in this issue's body or labels (e.g. "depends on #87").
+   - One or more of the doc's `tags` matches a label, file path, technology, or domain term from the issue.
+   - The `topic` slug clearly relates to the issue's subject matter.
+4. **Read the full body** of each relevant doc.
+5. **Surface findings** in a `## Research Context` block in the planning output, before phase design begins. List each relevant doc by topic with a 1-2 sentence takeaway, and quote any constraint that should shape phase boundaries.
+6. **Use the findings** when defining phases — especially to avoid re-discovering known constraints, to honor existing patterns, and to set realistic verification criteria.
+
+If no relevant docs are found, proceed without a Research Context block (do not output an empty heading).
+</research-retrieval>
 
 <planning-principles>
 **Phase Size:**
@@ -113,6 +133,32 @@ For each phase, capture:
 
 *Plan written to `.tiki/plans/issue-{number}.json`*
 </output>
+
+<research-capture>
+**As a side-effect of PLAN, capture planning-relevant constraints discovered while designing phases.**
+
+While exploring the codebase to design phase boundaries, you likely uncovered constraints that future plans (or future runs of this same plan) will benefit from — phase ordering rules, build-step dependencies, schema migration gotchas, framework command mirror requirements, "this must happen before that" knowledge, etc. Persist these by writing one or more research docs to `.tiki/research/<topic>.md`.
+
+Each research doc uses this YAML front-matter schema, then a free-form markdown body:
+
+```yaml
+---
+topic: <kebab-case-slug>
+tags: [tag1, tag2, tag3]
+issues: [{number}]
+created: <ISO 8601 timestamp>
+---
+```
+
+Rules:
+1. **Topic slug** is kebab-case derived from the constraint or pattern (e.g. `mirror-sync`, `phase-ordering`, `cargo-check-windows`).
+2. **Tags** are 2-5 short lowercase strings reflecting the categorization (planning, build, schema, etc.).
+3. **Issues** array includes the current issue number `[{number}]`.
+4. **Created** is the current ISO 8601 timestamp.
+5. **Skip** writing if the plan was straightforward and surfaced no constraints worth preserving — a trivial 2-phase plan that just edits one component does not need a research doc. Quality > quantity.
+6. **Append, do not overwrite.** If `.tiki/research/<topic>.md` already exists, read it and append a new section under a `## YYYY-MM-DD findings` heading rather than replacing the file. Extend the front-matter `issues` array if the current issue is not already listed.
+7. Focus on **planning-relevant** knowledge here — REVIEW captures domain understanding, PLAN captures the constraints that shaped phase boundaries.
+</research-capture>
 
 <early-state-update>
 **Before doing any planning work**, update `.tiki/state.json` so the issue appears in Active Work immediately:

--- a/packages/framework/commands/research.md
+++ b/packages/framework/commands/research.md
@@ -1,0 +1,131 @@
+---
+name: research
+description: Capture domain knowledge or findings into a research document
+argument: <topic>
+tools: Bash, Read, Write, Glob, AskUserQuestion
+---
+
+# Research Topic
+
+Capture domain knowledge, architecture findings, API conventions, or any non-trivial learning into a `.tiki/research/<topic>.md` document. Research docs are surfaced automatically during planning and execution to give Claude (and sub-agents) the context they need.
+
+<instructions>
+  <step>Parse the arguments:
+    - First positional argument is the **topic slug** (required, kebab-case, e.g. `github-api`, `auth-flow`).
+    - Optional `--issue N` flag attaches the doc to a specific GitHub issue (sets the `issues` field to `[N]`).
+    - If no topic is provided, ask the user via AskUserQuestion (or surface the no-argument error below).
+  </step>
+  <step>Validate the topic slug:
+    - Must be lowercase kebab-case (letters, digits, hyphens only).
+    - Must not contain `/` or `..` (path-traversal guard).
+    - Surface the `invalid-topic-slug` error if it fails validation.
+  </step>
+  <step>Determine the body content:
+    - If content was piped in (e.g. via stdin or a prior message), use it verbatim.
+    - Otherwise, use the conversation context: Claude already knows what the user wants captured from prior messages, so write the doc directly.
+    - If the topic is genuinely ambiguous, ask the user a single clarifying question before writing.
+  </step>
+  <step>Infer tags:
+    - Pick 2-5 short tags reflecting the topic (e.g. `[github, api, integration]`, `[auth, security]`, `[tauri, ipc]`).
+    - If unclear, ask the user via AskUserQuestion.
+  </step>
+  <step>Check for an existing doc at `.tiki/research/<topic>.md`:
+    - If it exists, read it and present an AskUserQuestion offering **Merge** (append a new `## YYYY-MM-DD findings` section to the existing body, preserving the original front-matter — but extend `issues` and `tags` arrays with new values, and update `created` only if missing) vs. **Overwrite** (replace the file entirely) vs. **Cancel**.
+    - If it does not exist, proceed to write a fresh file.
+  </step>
+  <step>Write `.tiki/research/<topic>.md` with the front-matter schema below, then the markdown body. Create the `.tiki/research/` directory if it does not exist.</step>
+  <step>Confirm to the user with the path and a one-line summary.</step>
+</instructions>
+
+<front-matter-schema>
+Every research doc starts with this YAML front-matter block:
+
+```yaml
+---
+topic: <kebab-case-slug>
+tags: [tag1, tag2, tag3]
+issues: [42, 87]
+created: <ISO 8601 timestamp>
+---
+```
+
+Field rules:
+- `topic`: same as the filename slug (without `.md`).
+- `tags`: a JSON-style array of short lowercase strings.
+- `issues`: a JSON-style array of integer issue numbers. Empty (`[]`) if not tied to a specific issue.
+- `created`: ISO 8601 timestamp at write time, e.g. `2026-05-08T17:42:00.000Z`.
+
+After the closing `---` delimiter, the rest of the file is free-form markdown.
+</front-matter-schema>
+
+<output>
+## Research Captured: {topic}
+
+**File:** `.tiki/research/{topic}.md`
+**Tags:** {tag1, tag2, ...}
+**Issues:** {[N] or "none"}
+
+---
+
+{First ~80 chars of the body as a preview...}
+
+---
+
+*Research saved. It will surface automatically during `/tiki:plan` and `/tiki:execute` when relevant.*
+</output>
+
+<example-output>
+For `/tiki:research github-api --issue 102`:
+
+## Research Captured: github-api
+
+**File:** `.tiki/research/github-api.md`
+**Tags:** github, api, integration
+**Issues:** [102]
+
+---
+
+This codebase uses the `gh` CLI for all GitHub Issue and PR access. Auth is checked via `gh auth status`...
+
+---
+
+*Research saved. It will surface automatically during `/tiki:plan` and `/tiki:execute` when relevant.*
+</example-output>
+
+<errors>
+  <error type="no-argument">
+    No topic provided. Please specify a topic slug:
+    ```
+    /tiki:research github-api
+    /tiki:research auth-flow --issue 42
+    ```
+  </error>
+  <error type="invalid-topic-slug">
+    Topic slug "{topic}" is invalid. Must be lowercase kebab-case (letters, digits, hyphens only) and must not contain `/` or `..`. Examples: `github-api`, `auth-flow`, `tauri-ipc`.
+  </error>
+  <error type="write-failed">
+    Failed to write `.tiki/research/{topic}.md`: {error message}. Check that the working directory is writable and that `.tiki/` exists.
+  </error>
+</errors>
+
+<next-actions>
+After saving the research doc, offer these options:
+
+1. **Plan the linked issue** - Continue with planning (`/tiki:plan {N}`) — only if `--issue N` was given.
+2. **Capture another topic** - Run `/tiki:research <other-topic>` again.
+3. **View the doc** - Open the new file for review.
+4. **Done** - Return to the previous workflow step.
+
+Present using AskUserQuestion with:
+- question: "Research saved. What's next?"
+- header: "Next step"
+- options:
+  - label: "Plan linked issue"
+    description: "Continue with /tiki:plan for the attached issue"
+  - label: "Capture another topic"
+    description: "Run /tiki:research again with a different topic"
+  - label: "View the doc"
+    description: "Open the new research file"
+  - label: "Done"
+    description: "Return to the previous step"
+</next-actions>

--- a/packages/framework/commands/review.md
+++ b/packages/framework/commands/review.md
@@ -110,6 +110,32 @@ Prefix each with an ID: SC1, SC2, SC3, etc.
 *Review complete. Ready to plan.*
 </output>
 
+<research-capture>
+**As a side-effect of REVIEW, capture domain understanding from codebase exploration.**
+
+While analyzing the codebase to understand this issue, you likely uncovered non-trivial knowledge — architecture patterns, API conventions, hidden constraints, data models, important file conventions, auth flows, IPC contracts, etc. Persist anything that future planning or execution might need by writing one or more research docs to `.tiki/research/<topic>.md`.
+
+Each research doc uses this YAML front-matter schema, then a free-form markdown body:
+
+```yaml
+---
+topic: <kebab-case-slug>
+tags: [tag1, tag2, tag3]
+issues: [{number}]
+created: <ISO 8601 timestamp>
+---
+```
+
+Rules:
+1. **Topic slug** is kebab-case derived from the subject (e.g. `auth-flow`, `tauri-watcher`, `state-schema`).
+2. **Tags** are 2-5 short lowercase strings reflecting the categorization.
+3. **Issues** array includes the current issue number `[{number}]`.
+4. **Created** is the current ISO 8601 timestamp.
+5. **Skip** writing if the issue is purely a one-line bug fix or has no meaningful domain learning. Quality > quantity — do not pad output with shallow notes.
+6. **Append, do not overwrite.** If `.tiki/research/<topic>.md` already exists, read it and append a new section under a `## YYYY-MM-DD findings` heading rather than replacing the file. Extend the front-matter `issues` array if the current issue is not already listed.
+7. Multiple research docs are fine if findings span distinct topics — write one file per coherent topic rather than a single grab-bag.
+</research-capture>
+
 <state-management>
 Update `.tiki/state.json` after review:
 - Change status from `pending` to `reviewing`


### PR DESCRIPTION
## Summary

Resolves #102. Adds `/tiki:research` command and knowledge-capture system across framework + desktop.

- New `/tiki:research <topic>` manual command writes `.tiki/research/<topic>.md` with YAML front-matter (topic, tags, issues, created)
- `review.md` and `plan.md` auto-capture domain findings as a side-effect
- `plan.md` and `execute.md` auto-retrieve relevant research; execute.md injects it into sub-agent prompts
- Rust IPC: `list_research_docs`, `read_research_doc`, `ResearchChanged` watcher event
- Desktop: ResearchSection sidebar + ResearchDetail panel with markdown rendering

## Test plan

- [ ] Run \`/tiki:research example-topic\` in Claude Code; verify `.tiki/research/example-topic.md` is created with valid front-matter
- [ ] Open desktop app; confirm ResearchSection appears in sidebar with example-research.md listed
- [ ] Click a research doc; confirm ResearchDetail renders front-matter header + markdown body
- [ ] Edit a research doc on disk; confirm sidebar refreshes via watcher event
- [ ] Run `/tiki:review` on an issue; confirm a research doc is auto-captured if domain learning is non-trivial
- [ ] `pnpm build` from repo root passes
- [ ] `cargo check` in `apps/desktop/src-tauri` passes

Part of release v0.2.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)