### PR TITLE
feat: auto-healing for failed phases (#101)

### DIFF
--- a/.tiki/config.json
+++ b/.tiki/config.json
@@ -1,0 +1,9 @@
+{
+  "workflow": {
+    "autoHeal": {
+      "enabled": false,
+      "maxAttempts": 3,
+      "categories": ["build-error", "type-error", "test-failure", "lint-error"]
+    }
+  }
+}

--- a/.tiki/plans/issue-101.json
+++ b/.tiki/plans/issue-101.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": 1,
+  "issue": {
+    "number": 101,
+    "title": "Auto-healing for failed phases",
+    "url": "https://github.com/Eric-Ness/Tiki-V2/issues/101"
+  },
+  "createdAt": "2026-05-08T00:00:00.000Z",
+  "successCriteria": [
+    { "id": "SC1", "category": "config", "description": "Auto-heal is opt-in via .tiki/config.json with workflow.autoHeal.{enabled,maxAttempts,categories}; absent file disables auto-heal by default" },
+    { "id": "SC2", "category": "behavior", "description": "When verification fails and auto-heal is enabled, execute.md instructs Claude to capture error output, categorize it, and attempt a targeted fix" },
+    { "id": "SC3", "category": "behavior", "description": "Auto-heal attempts are capped at config.workflow.autoHeal.maxAttempts (default 3); on exhaustion, Claude falls back to manual <next-actions> recovery" },
+    { "id": "SC4", "category": "transparency", "description": "Each heal attempt is logged as a HealAttempt record in .tiki/state.json under the phase's healAttempts array; the manual fallback summarizes all attempts" },
+    { "id": "SC5", "category": "categorization", "description": "Errors are categorized into build-error, type-error, test-failure, lint-error, or other, with brief healing-strategy guidance per category" },
+    { "id": "SC6", "category": "consistency", "description": "Source execute.md (packages/framework/commands/execute.md) and mirror (packages/framework/.claude/commands/tiki/execute.md) are byte-for-byte identical" },
+    { "id": "SC7", "category": "regression", "description": "pnpm build from repo root passes with no TypeScript errors" }
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "title": "Add <auto-heal> block to execute.md (source + mirror)",
+      "status": "pending",
+      "content": "Modify `packages/framework/commands/execute.md` to add a new `<auto-heal>` XML block describing the opt-in heal loop. Place it AFTER the existing `<errors>` section and BEFORE `<next-actions>`.\n\nThe `<auto-heal>` block must cover:\n1. **Opt-in check** — read `.tiki/config.json`, look for `workflow.autoHeal.enabled === true`. Treat missing file as disabled.\n2. **Heal loop** — when verification fails AND auto-heal is enabled:\n   a. Capture error output verbatim (preserve filenames, line numbers, diagnostic messages)\n   b. Categorize the error: `build-error` / `type-error` / `test-failure` / `lint-error` / `other`\n   c. Read prior attempts from `.tiki/state.json` at `activeWork[\"issue:{N}\"].phase.healAttempts`\n   d. Stop conditions: attempts >= maxAttempts (default 3), category not in allow-list, or repeating same error\n   e. Attempt a targeted fix and re-run verification\n   f. Append a `HealAttempt` record `{ attempt, timestamp, errorCategory, errorSummary, fixApplied, outcome }` to `phase.healAttempts` regardless of outcome\n3. **Healing strategies** per category (brief guidance, not prescription):\n   - build-error: smallest mechanical fix (imports, signatures, missing serde defaults)\n   - type-error: re-read types; prefer ternary over intermediate booleans for discriminated-union narrowing\n   - test-failure: decide whether test or implementation diverges from phase goal\n   - lint-error: apply suggested fix\n   - other: fall through to manual recovery\n4. **Fallback** — when exhausted, present manual `<next-actions>` \"After failure\" flow with a summary of all heal attempts so the user knows what was tried.\n\nAlso update `<instructions>`: change the verification-failure step to reference `<auto-heal>`. Specifically replace `If verification fails, offer recovery options` with `If verification fails, follow <auto-heal> (when enabled in .tiki/config.json) before offering manual recovery options`.\n\nAfter editing the source, copy it byte-for-byte to `packages/framework/.claude/commands/tiki/execute.md`. Verify with `Get-FileHash` that the hashes match.",
+      "verification": [
+        "packages/framework/commands/execute.md contains an <auto-heal> block placed between <errors> and <next-actions>",
+        "<auto-heal> covers: opt-in check, 8-step heal loop, per-category healing strategies, manual fallback with attempts summary",
+        "<instructions> step about verification failure references <auto-heal>",
+        "packages/framework/.claude/commands/tiki/execute.md is byte-for-byte identical to the source (Get-FileHash matches)",
+        "pnpm build from repo root passes"
+      ],
+      "addressesCriteria": ["SC2", "SC3", "SC4", "SC5", "SC6", "SC7"],
+      "files": [
+        "packages/framework/commands/execute.md",
+        "packages/framework/.claude/commands/tiki/execute.md"
+      ],
+      "dependencies": []
+    },
+    {
+      "number": 2,
+      "title": "Create .tiki/config.json with default auto-heal schema",
+      "status": "pending",
+      "content": "Create `.tiki/config.json` with the default auto-heal configuration:\n\n```json\n{\n  \"workflow\": {\n    \"autoHeal\": {\n      \"enabled\": false,\n      \"maxAttempts\": 3,\n      \"categories\": [\"build-error\", \"type-error\", \"test-failure\", \"lint-error\"]\n    }\n  }\n}\n```\n\nKey decisions:\n- `enabled: false` by default — auto-heal is opt-in. Users flip this to `true` to activate the loop.\n- `maxAttempts: 3` — reasonable cap matching the issue's \"max 2-3 retries\" requirement.\n- `categories` enumerates all heal-eligible error types. Removing one disables auto-heal for that category.\n- The file is optional; absence is equivalent to `enabled: false`. The Rust state machine does not read this file — it is purely a Claude-driven configuration consumed at execute-time.\n\nDo not add JSON comments (not valid in JSON). The schema is self-documenting via execute.md's `<auto-heal>` block.",
+      "verification": [
+        ".tiki/config.json exists with the documented schema",
+        "workflow.autoHeal.enabled is false by default",
+        "workflow.autoHeal.maxAttempts is 3",
+        "workflow.autoHeal.categories includes build-error, type-error, test-failure, lint-error",
+        "File is valid JSON (parses without error)"
+      ],
+      "addressesCriteria": ["SC1"],
+      "files": [".tiki/config.json"],
+      "dependencies": []
+    }
+  ],
+  "coverageMatrix": {
+    "SC1": [2],
+    "SC2": [1],
+    "SC3": [1],
+    "SC4": [1],
+    "SC5": [1],
+    "SC6": [1],
+    "SC7": [1]
+  }
+}

--- a/packages/framework/.claude/commands/tiki/execute.md
+++ b/packages/framework/.claude/commands/tiki/execute.md
@@ -21,7 +21,7 @@ Execute the phases of a planned issue. Each phase runs with focused context, pro
     5. Update phase status and save state
   </step>
   <step>If verification passes, advance to next phase or complete</step>
-  <step>If verification fails, offer recovery options</step>
+  <step>If verification fails, follow `<auto-heal>` (when enabled in `.tiki/config.json`) before offering manual recovery options</step>
 </instructions>
 
 <state-update-requirement>
@@ -242,6 +242,96 @@ During execution, update `.tiki/state.json`:
     - Pause execution
   </error>
 </errors>
+
+<auto-heal>
+## Auto-Heal: Automatic Recovery on Verification Failure
+
+When a phase's verification step fails, Tiki can attempt to repair the failure automatically before falling back to the manual recovery options in `<next-actions>`. Auto-heal is **opt-in** and is driven entirely by these instructions — there is no Rust code that runs the heal loop.
+
+### Opt-in check
+
+Before attempting auto-heal, read `.tiki/config.json` (it may not exist).
+
+```json
+{
+  "workflow": {
+    "autoHeal": {
+      "enabled": false,
+      "maxAttempts": 3,
+      "categories": ["build-error", "type-error", "test-failure", "lint-error"]
+    }
+  }
+}
+```
+
+- If the file is missing, treat `enabled` as `false` and skip auto-heal entirely (use the manual `<next-actions>` failure flow).
+- If `workflow.autoHeal.enabled !== true`, skip auto-heal.
+- `maxAttempts` defaults to `3` when missing.
+- `categories` is the allow-list of error categories you may attempt to heal. If the categorized error is not in this list, skip auto-heal and fall through to manual recovery.
+
+### Heal loop
+
+When verification fails AND auto-heal is enabled:
+
+1. **Capture the error output** verbatim (build stderr, failing test names, type errors, lint diagnostics, etc.). Trim aggressively but preserve filenames, line numbers, and the diagnostic message.
+2. **Categorize the error** using the heuristics below. Pick exactly one category:
+   - `build-error` — TypeScript `tsc -b` / `pnpm build` compilation failures, Rust `cargo check` / `cargo build` failures (non-type)
+   - `type-error` — TS-only type narrowing, missing properties on types, discriminated-union narrowing issues
+   - `test-failure` — vitest, jest, or `cargo test` failed assertions or runtime errors during tests
+   - `lint-error` — ESLint, clippy diagnostics
+   - `other` — anything else (e.g., missing file, permission error, network failure)
+3. **Read prior attempts** for this phase from `.tiki/state.json`. Look at `activeWork["issue:{N}"].phase.healAttempts` (treat as `[]` if missing). Let `attempts = healAttempts.length`.
+4. **Stop conditions** — fall through to manual `<next-actions>` recovery if any of these are true:
+   - `attempts >= config.workflow.autoHeal.maxAttempts`
+   - The categorized error is not in `config.workflow.autoHeal.categories`
+   - The same error has already been seen on the previous attempt with no progress (heal is looping)
+5. **Otherwise, attempt a targeted fix** based on category (see "Healing strategies" below). Apply the fix as a normal edit, then **re-run the same verification command** that originally failed.
+6. **Append a `HealAttempt` record** to `phase.healAttempts` in `.tiki/state.json` regardless of outcome:
+   ```json
+   {
+     "attempt": {1-indexed},
+     "timestamp": "{ISO timestamp}",
+     "errorCategory": "type-error",
+     "errorSummary": "{one-line summary, ~120 chars}",
+     "fixApplied": "{one-line description of the change}",
+     "outcome": "success" | "failure"
+   }
+   ```
+7. **On success**, clear the failure state and continue to the next phase normally. Include the heal attempts in the phase summary so they are visible.
+8. **On failure**, loop back to step 1 with the new error output. The next iteration's `attempt` count increments naturally because the prior record was appended.
+
+### Healing strategies (per category)
+
+These are guidance, not prescriptions — judge each error on its merits.
+
+- **build-error** — Read the offending file at the reported line. If the failure references a missing import/export, fix the import path. If a function signature mismatch, align the call site or the declaration based on which is canonical (prefer matching the type definition). For Rust, common fixes are missing `use` statements, missing `#[serde(default)]` on optional fields, or trait bound issues — try the smallest mechanical fix first.
+- **type-error** — Re-read the type definitions involved. For TS discriminated-union narrowing, prefer extracting fields via direct ternary (per project memory: `const x = work.type === "issue" ? work.issue.number : undefined;`) rather than intermediate booleans. Add explicit type assertions only as a last resort.
+- **test-failure** — Read the failing test, then re-read the implementation. Decide whether the test's expectation or the implementation is correct. Fix the side that diverges from the phase's stated goal. If the failing assertion is unrelated to this phase's changes, flag as `other` and bail to manual recovery.
+- **lint-error** — Apply the lint rule's suggested fix. For ESLint, prefer auto-fixable rules (`pnpm lint --fix` if available); for clippy, apply the suggested replacement.
+- **other** — Do not attempt auto-heal. Fall through to manual recovery and let the user decide.
+
+### Falling back to manual recovery
+
+When auto-heal exhausts its attempts (or refuses to start), present the manual `<next-actions>` failure flow with one important addition: **include a summary of all heal attempts** so the user knows what was tried. Format:
+
+```
+Auto-heal attempted {N} fixes for Phase {N} but verification still fails.
+
+Attempts:
+1. [type-error] Fixed discriminated-union narrowing in WorkCard.tsx → still failing (different error)
+2. [type-error] Added explicit type assertion → still failing (same error)
+3. [build-error] Reverted assertion, fixed import path → still failing
+
+Latest error:
+{error output}
+```
+
+Then fire the existing `AskUserQuestion` from `<next-actions>` "After failure".
+
+### Where to record attempts
+
+`HealAttempt` records live in `.tiki/state.json` under the active work item's `phase.healAttempts` array. The Rust state schema treats this loosely (no validation), so you can write the array directly. Do not create a separate file.
+</auto-heal>
 
 <next-actions>
 **After successful phase:**

--- a/packages/framework/commands/execute.md
+++ b/packages/framework/commands/execute.md
@@ -21,7 +21,7 @@ Execute the phases of a planned issue. Each phase runs with focused context, pro
     5. Update phase status and save state
   </step>
   <step>If verification passes, advance to next phase or complete</step>
-  <step>If verification fails, offer recovery options</step>
+  <step>If verification fails, follow `<auto-heal>` (when enabled in `.tiki/config.json`) before offering manual recovery options</step>
 </instructions>
 
 <state-update-requirement>
@@ -242,6 +242,96 @@ During execution, update `.tiki/state.json`:
     - Pause execution
   </error>
 </errors>
+
+<auto-heal>
+## Auto-Heal: Automatic Recovery on Verification Failure
+
+When a phase's verification step fails, Tiki can attempt to repair the failure automatically before falling back to the manual recovery options in `<next-actions>`. Auto-heal is **opt-in** and is driven entirely by these instructions — there is no Rust code that runs the heal loop.
+
+### Opt-in check
+
+Before attempting auto-heal, read `.tiki/config.json` (it may not exist).
+
+```json
+{
+  "workflow": {
+    "autoHeal": {
+      "enabled": false,
+      "maxAttempts": 3,
+      "categories": ["build-error", "type-error", "test-failure", "lint-error"]
+    }
+  }
+}
+```
+
+- If the file is missing, treat `enabled` as `false` and skip auto-heal entirely (use the manual `<next-actions>` failure flow).
+- If `workflow.autoHeal.enabled !== true`, skip auto-heal.
+- `maxAttempts` defaults to `3` when missing.
+- `categories` is the allow-list of error categories you may attempt to heal. If the categorized error is not in this list, skip auto-heal and fall through to manual recovery.
+
+### Heal loop
+
+When verification fails AND auto-heal is enabled:
+
+1. **Capture the error output** verbatim (build stderr, failing test names, type errors, lint diagnostics, etc.). Trim aggressively but preserve filenames, line numbers, and the diagnostic message.
+2. **Categorize the error** using the heuristics below. Pick exactly one category:
+   - `build-error` — TypeScript `tsc -b` / `pnpm build` compilation failures, Rust `cargo check` / `cargo build` failures (non-type)
+   - `type-error` — TS-only type narrowing, missing properties on types, discriminated-union narrowing issues
+   - `test-failure` — vitest, jest, or `cargo test` failed assertions or runtime errors during tests
+   - `lint-error` — ESLint, clippy diagnostics
+   - `other` — anything else (e.g., missing file, permission error, network failure)
+3. **Read prior attempts** for this phase from `.tiki/state.json`. Look at `activeWork["issue:{N}"].phase.healAttempts` (treat as `[]` if missing). Let `attempts = healAttempts.length`.
+4. **Stop conditions** — fall through to manual `<next-actions>` recovery if any of these are true:
+   - `attempts >= config.workflow.autoHeal.maxAttempts`
+   - The categorized error is not in `config.workflow.autoHeal.categories`
+   - The same error has already been seen on the previous attempt with no progress (heal is looping)
+5. **Otherwise, attempt a targeted fix** based on category (see "Healing strategies" below). Apply the fix as a normal edit, then **re-run the same verification command** that originally failed.
+6. **Append a `HealAttempt` record** to `phase.healAttempts` in `.tiki/state.json` regardless of outcome:
+   ```json
+   {
+     "attempt": {1-indexed},
+     "timestamp": "{ISO timestamp}",
+     "errorCategory": "type-error",
+     "errorSummary": "{one-line summary, ~120 chars}",
+     "fixApplied": "{one-line description of the change}",
+     "outcome": "success" | "failure"
+   }
+   ```
+7. **On success**, clear the failure state and continue to the next phase normally. Include the heal attempts in the phase summary so they are visible.
+8. **On failure**, loop back to step 1 with the new error output. The next iteration's `attempt` count increments naturally because the prior record was appended.
+
+### Healing strategies (per category)
+
+These are guidance, not prescriptions — judge each error on its merits.
+
+- **build-error** — Read the offending file at the reported line. If the failure references a missing import/export, fix the import path. If a function signature mismatch, align the call site or the declaration based on which is canonical (prefer matching the type definition). For Rust, common fixes are missing `use` statements, missing `#[serde(default)]` on optional fields, or trait bound issues — try the smallest mechanical fix first.
+- **type-error** — Re-read the type definitions involved. For TS discriminated-union narrowing, prefer extracting fields via direct ternary (per project memory: `const x = work.type === "issue" ? work.issue.number : undefined;`) rather than intermediate booleans. Add explicit type assertions only as a last resort.
+- **test-failure** — Read the failing test, then re-read the implementation. Decide whether the test's expectation or the implementation is correct. Fix the side that diverges from the phase's stated goal. If the failing assertion is unrelated to this phase's changes, flag as `other` and bail to manual recovery.
+- **lint-error** — Apply the lint rule's suggested fix. For ESLint, prefer auto-fixable rules (`pnpm lint --fix` if available); for clippy, apply the suggested replacement.
+- **other** — Do not attempt auto-heal. Fall through to manual recovery and let the user decide.
+
+### Falling back to manual recovery
+
+When auto-heal exhausts its attempts (or refuses to start), present the manual `<next-actions>` failure flow with one important addition: **include a summary of all heal attempts** so the user knows what was tried. Format:
+
+```
+Auto-heal attempted {N} fixes for Phase {N} but verification still fails.
+
+Attempts:
+1. [type-error] Fixed discriminated-union narrowing in WorkCard.tsx → still failing (different error)
+2. [type-error] Added explicit type assertion → still failing (same error)
+3. [build-error] Reverted assertion, fixed import path → still failing
+
+Latest error:
+{error output}
+```
+
+Then fire the existing `AskUserQuestion` from `<next-actions>` "After failure".
+
+### Where to record attempts
+
+`HealAttempt` records live in `.tiki/state.json` under the active work item's `phase.healAttempts` array. The Rust state schema treats this loosely (no validation), so you can write the array directly. Do not create a separate file.
+</auto-heal>
 
 <next-actions>
 **After successful phase:**


### PR DESCRIPTION
## Summary

Resolves #101. Adds opt-in auto-heal loop in `execute.md` that recovers from common phase verification failures (build, type, test, lint errors) before falling back to manual intervention.

- `<auto-heal>` block in execute.md describes the loop: detect failure → categorize → fix → re-verify, up to `maxAttempts` times
- New `.tiki/config.json` with `workflow.autoHeal` section (default disabled); user opts in by setting `enabled: true`
- HealAttempt records persist in phase progress for transparency
- Mirror in `packages/framework/.claude/commands/tiki/` synced

## Test plan

- [ ] With `auto-heal.enabled: false` (default), a failing phase still presents the existing manual recovery menu — no behavior change
- [ ] With `auto-heal.enabled: true`, Claude attempts a categorized fix when verification fails, retries up to maxAttempts, then surfaces fall-through menu
- [ ] HealAttempt records appear in `.tiki/state.json` phase progress after each attempt
- [ ] `pnpm build` passes
- [ ] Mirror file in `.claude/commands/tiki/execute.md` matches the source

Part of release v0.2.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)