### PR TITLE
feat: automated test framework integration (#100)

### DIFF
--- a/.tiki/config.json
+++ b/.tiki/config.json
@@ -1,0 +1,11 @@
+{
+  "workflow": {
+    "tests": {
+      "enabled": true,
+      "command": null,
+      "runOnEachPhase": false,
+      "runBeforeShip": true,
+      "timeoutSeconds": 300
+    }
+  }
+}

--- a/.tiki/plans/issue-100.json
+++ b/.tiki/plans/issue-100.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": 1,
+  "issue": {
+    "number": 100,
+    "title": "Automated test framework integration",
+    "url": "https://github.com/Eric-Ness/Tiki-V2/issues/100"
+  },
+  "createdAt": "2026-05-08T00:00:00.000Z",
+  "successCriteria": [
+    { "id": "SC1", "category": "functionality", "description": "Test framework auto-detection algorithm documented in execute.md (vitest/jest/pytest/cargo/go in priority order)" },
+    { "id": "SC2", "category": "functionality", "description": "Test run is integrated into per-phase verification, gated by config and the phase's verification array" },
+    { "id": "SC3", "category": "functionality", "description": "Test output parsing patterns documented for each supported framework, with exit-code fallback" },
+    { "id": "SC4", "category": "functionality", "description": "testResults block (framework, command, passed/failed/skipped, durationMs, status) is surfaced in the phase summary" },
+    { "id": "SC5", "category": "functionality", "description": "Full test suite runs before SHIP commit; failure halts ship and prompts user via AskUserQuestion (Pause / Skip / Abort)" },
+    { "id": "SC6", "category": "config", "description": ".tiki/config.json supports workflow.tests with enabled, command override, runOnEachPhase, runBeforeShip, timeoutSeconds" },
+    { "id": "SC7", "category": "ux", "description": "Test failure details (last ~50 lines of output) are surfaced in phase error output before recovery flow" }
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "title": "Add <test-integration> block to execute.md",
+      "status": "pending",
+      "content": "Add a new `<test-integration>` XML block to `packages/framework/commands/execute.md` (and the byte-for-byte mirror at `packages/framework/.claude/commands/tiki/execute.md`).\n\nThe block must describe:\n\n1. **Configuration read** — load `.tiki/config.json`, find `workflow.tests`, with defaults `{ enabled: true, command: null, runOnEachPhase: false, runBeforeShip: true, timeoutSeconds: 300 }` if the file or section is missing. If `enabled: false`, record `{ status: \"skipped\", reason: \"tests disabled in config\" }` and exit the block.\n\n2. **Run gate** — only run tests when `runOnEachPhase: true` OR when the current phase's `verification` array contains an entry whose lowercased text matches `vitest`, `jest`, `pnpm test`, `npm test`, `cargo test`, `go test`, `pytest`, or the bare token `test`.\n\n3. **Command resolution** — if `workflow.tests.command` is set, use it directly. Otherwise auto-detect by file presence in priority order: `package.json scripts.test` → vitest dep → jest dep → `Cargo.toml` → `go.mod` → pytest (`pytest.ini`, `[tool.pytest]` in pyproject, or `tests/` with `.py`). If none match, record `{ status: \"skipped\", reason: \"no framework detected\" }`.\n\n4. **Run** — execute resolved command from project root with timeout `workflow.tests.timeoutSeconds`. Capture stdout, stderr, exit code, elapsed time.\n\n5. **Parsing patterns** — best-effort grep for vitest (`Test Files  N passed`), jest (`Tests:  N passed, N total`), pytest (`N passed in N.NNs`), cargo (`test result: ok. N passed; N failed`), go (PASS lines per package; `--json` optional). Fall back to exit code on parse failure.\n\n6. **Surface in summary** — add a `testResults` field with shape `{ framework, command, passed, failed, skipped, durationMs, status }` to the phase summary.\n\n7. **On failure** — include last ~50 lines of test output in phase error output before falling through to standard verification-failed recovery.\n\nAlso include a single line: \"Hook-based override is out of scope for v1; use `.tiki/config.json`.\"\n\nUpdate `<instructions>` to add a sub-step \"Run test integration before declaring verification passed\" and reference `testResults` in the summary step.\n\nInsert the new `<test-integration>` block immediately before `<next-actions>`.\n\nApply identical changes to the mirror at `packages/framework/.claude/commands/tiki/execute.md`.",
+      "verification": [
+        "execute.md contains a <test-integration> block placed before <next-actions>",
+        "execute.md <instructions> references the new test integration step",
+        "Mirror at packages/framework/.claude/commands/tiki/execute.md is byte-for-byte identical for the inserted block",
+        "pnpm build from repo root passes"
+      ],
+      "addressesCriteria": ["SC1", "SC2", "SC3", "SC4", "SC7"],
+      "files": [
+        "packages/framework/commands/execute.md",
+        "packages/framework/.claude/commands/tiki/execute.md"
+      ],
+      "dependencies": []
+    },
+    {
+      "number": 2,
+      "title": "Add <pre-ship-tests> block to ship.md",
+      "status": "pending",
+      "content": "Add a new `<pre-ship-tests>` XML block to `packages/framework/commands/ship.md` (and the byte-for-byte mirror at `packages/framework/.claude/commands/tiki/ship.md`).\n\nThe block must describe:\n\n1. **Configuration read** — load `.tiki/config.json` `workflow.tests`. Defaults `{ enabled: true, command: null, runBeforeShip: true, timeoutSeconds: 300 }`. Skip if `enabled: false` OR `runBeforeShip: false` (record skipped reason and continue ship).\n\n2. **Command resolution** — same priority-order auto-detection as `<test-integration>` in execute.md. If `command` is set, use it.\n\n3. **Run full suite** — no phase filters. Timeout = `workflow.tests.timeoutSeconds`.\n\n4. **Parse and report** — same patterns; produce a `testResults` block in the ship report.\n\n5. **On failure** — DO NOT commit. Surface last ~50 lines of test output. Present an `AskUserQuestion` with three options:\n   - \"Pause to fix tests (Recommended)\" → set work status to `paused`, leave pipelineStep as `SHIP`, exit\n   - \"Skip tests and ship anyway\" → continue commit, note override in commit body and GitHub close comment\n   - \"Abort ship\" → set work status back to `executing`, exit without committing\n\nUpdate `<instructions>` to add a step \"Run the full test suite (see `<pre-ship-tests>` block) before committing. Halt and prompt the user if tests fail.\" between the existing run-final-verification step and the stage/commit step.\n\nInsert `<pre-ship-tests>` immediately after `</pre-ship-verification>` and before `<commit-format>`.\n\nApply identical changes to the mirror at `packages/framework/.claude/commands/tiki/ship.md`.",
+      "verification": [
+        "ship.md contains a <pre-ship-tests> block placed between </pre-ship-verification> and <commit-format>",
+        "ship.md <instructions> references the new pre-ship test step",
+        "Mirror at packages/framework/.claude/commands/tiki/ship.md is byte-for-byte identical for the inserted block",
+        "pnpm build from repo root passes"
+      ],
+      "addressesCriteria": ["SC5"],
+      "files": [
+        "packages/framework/commands/ship.md",
+        "packages/framework/.claude/commands/tiki/ship.md"
+      ],
+      "dependencies": []
+    },
+    {
+      "number": 3,
+      "title": "Create .tiki/config.json with workflow.tests section",
+      "status": "pending",
+      "content": "Create `.tiki/config.json` with the `workflow.tests` configuration section so the markdown commands have a real config to read.\n\nFile contents:\n\n```json\n{\n  \"workflow\": {\n    \"tests\": {\n      \"enabled\": true,\n      \"command\": null,\n      \"runOnEachPhase\": false,\n      \"runBeforeShip\": true,\n      \"timeoutSeconds\": 300\n    }\n  }\n}\n```\n\nNote: PR #101 (auto-healing, sibling branch) creates the same file with a `workflow.autoHeal` section. When both PRs land, a merge conflict on `.tiki/config.json` is expected — resolution combines both sections under the shared `workflow` key.",
+      "verification": [
+        ".tiki/config.json exists at repo root",
+        "File parses as valid JSON",
+        "workflow.tests.enabled === true",
+        "workflow.tests.runBeforeShip === true",
+        "workflow.tests.runOnEachPhase === false",
+        "workflow.tests.timeoutSeconds === 300",
+        "workflow.tests.command === null",
+        "pnpm build from repo root passes"
+      ],
+      "addressesCriteria": ["SC6"],
+      "files": [".tiki/config.json"],
+      "dependencies": []
+    }
+  ],
+  "coverageMatrix": {
+    "SC1": [1],
+    "SC2": [1],
+    "SC3": [1],
+    "SC4": [1],
+    "SC5": [2],
+    "SC6": [3],
+    "SC7": [1]
+  }
+}

--- a/packages/framework/.claude/commands/tiki/execute.md
+++ b/packages/framework/.claude/commands/tiki/execute.md
@@ -17,11 +17,12 @@ Execute the phases of a planned issue. Each phase runs with focused context, pro
     1. Display phase details (title, files, verification criteria)
     2. Execute the phase content (the actual work)
     3. Run verification checks
-    4. Generate a summary of what was accomplished
-    5. Update phase status and save state
+    4. Run test integration (see `<test-integration>` block) before declaring verification passed
+    5. Generate a summary of what was accomplished (include `testResults` if tests ran)
+    6. Update phase status and save state
   </step>
   <step>If verification passes, advance to next phase or complete</step>
-  <step>If verification fails, offer recovery options</step>
+  <step>If verification fails (including test failures), surface details and offer recovery options</step>
 </instructions>
 
 <state-update-requirement>
@@ -242,6 +243,94 @@ During execution, update `.tiki/state.json`:
     - Pause execution
   </error>
 </errors>
+
+<test-integration>
+## Test Framework Integration
+
+After phase work completes, run the project's test suite as part of verification. Test results are surfaced in the phase summary as `testResults`.
+
+> Hook-based override is out of scope for v1; use `.tiki/config.json`.
+
+### 1. Read configuration
+
+Read `.tiki/config.json` and look for `workflow.tests`. Defaults if file/section is absent:
+
+```json
+{
+  "enabled": true,
+  "command": null,
+  "runOnEachPhase": false,
+  "runBeforeShip": true,
+  "timeoutSeconds": 300
+}
+```
+
+If `workflow.tests.enabled` is `false`, skip this block entirely (record `{ status: "skipped", reason: "tests disabled in config" }`).
+
+### 2. Decide whether to run
+
+Run tests for this phase only if **either** is true:
+- `workflow.tests.runOnEachPhase` is `true`, OR
+- The current phase's `verification` array explicitly mentions a test step — any entry whose lowercased text contains one of: `vitest`, `jest`, `pnpm test`, `npm test`, `cargo test`, `go test`, `pytest`, or the bare token `test` (word boundary).
+
+Otherwise, skip with `{ status: "skipped", reason: "phase verification does not require tests" }`.
+
+### 3. Resolve the test command
+
+If `workflow.tests.command` is set (non-null string), use it directly — this overrides detection.
+
+Otherwise, auto-detect by checking project files in this priority order:
+
+1. **`package.json` with `scripts.test`** → use `pnpm test` if `pnpm-lock.yaml` exists, else `npm test`
+2. **`package.json` with `vitest` in deps/devDeps** → `pnpm vitest run` (or `npx vitest run` if no pnpm lockfile)
+3. **`package.json` with `jest` in deps/devDeps** → `pnpm jest` (or `npx jest`)
+4. **`Cargo.toml` present** → `cargo test`
+5. **`go.mod` present** → `go test ./...`
+6. **`pytest.ini` OR `pyproject.toml` containing `[tool.pytest]` OR a `tests/` directory containing `.py` files** → `pytest`
+
+If none match, record `{ status: "skipped", reason: "no framework detected" }` and continue.
+
+### 4. Run
+
+Run the resolved command from the project root with a timeout of `workflow.tests.timeoutSeconds` (default 300). Capture stdout, stderr, exit code, and elapsed time.
+
+### 5. Parse output
+
+Best-effort grep the combined stdout/stderr for these patterns. Always set `framework` to the detected/configured framework name (`vitest`, `jest`, `pytest`, `cargo`, `go`, `npm`, `unknown`).
+
+- **vitest:** `Test Files  N passed`, `Tests  N passed` (also `failed`, `skipped`)
+- **jest:** `Tests:  N passed, N total` (also `failed`, `skipped`)
+- **pytest:** `N passed in N.NNs` (also `N failed`, `N skipped`)
+- **cargo:** `test result: ok. N passed; N failed` (also `N ignored`)
+- **go:** `PASS\nok ...` per package; `--json` output gives structured pass/fail counts (optional)
+
+If parsing fails, fall back to exit code: `0 → status: "passed"` with counts unknown, non-zero → `status: "failed"`.
+
+### 6. Surface in phase summary
+
+Add a `testResults` field to the phase summary:
+
+```typescript
+testResults: {
+  framework: string;       // "vitest" | "jest" | "pytest" | "cargo" | "go" | "npm" | "unknown"
+  command: string;         // the command actually run
+  passed: number;          // 0 if unknown
+  failed: number;
+  skipped: number;
+  durationMs: number;
+  status: "passed" | "failed" | "skipped";
+}
+```
+
+### 7. On test failure
+
+If `testResults.status === "failed"`:
+1. Mark phase verification as failed.
+2. Include the failing test output (last ~50 lines of stdout/stderr) in the phase error output BEFORE falling through to the standard `verification-failed` recovery flow.
+3. Do not advance to the next phase.
+
+The recovery options under `<next-actions>` (Fix and retry / Skip / Pause / Heal) apply normally — auto-heal hooks (if installed by a future issue) can pick up `testResults` to drive repair.
+</test-integration>
 
 <next-actions>
 **After successful phase:**

--- a/packages/framework/.claude/commands/tiki/ship.md
+++ b/packages/framework/.claude/commands/tiki/ship.md
@@ -18,6 +18,7 @@ Finalize an issue by committing changes, pushing to remote, and closing the GitH
     - Build succeeds
     - No uncommitted changes from unrelated work
   </step>
+  <step>Run the full test suite (see `<pre-ship-tests>` block) before committing. Halt and prompt the user if tests fail.</step>
   <step>Stage and commit changes with a descriptive message</step>
   <step>Push to remote</step>
   <step>Close the GitHub issue with a summary comment</step>
@@ -47,6 +48,72 @@ Before shipping, verify:
 - [ ] No unrelated changes mixed in
 - [ ] Working directory is clean after commit
 </pre-ship-verification>
+
+<pre-ship-tests>
+## Pre-Ship Test Run
+
+Before staging and committing, run the full project test suite. This catches regressions that phase-level verification may have missed.
+
+### 1. Read configuration
+
+Read `.tiki/config.json` and look for `workflow.tests`. Defaults if file/section is absent:
+
+```json
+{
+  "enabled": true,
+  "command": null,
+  "runBeforeShip": true,
+  "timeoutSeconds": 300
+}
+```
+
+If `workflow.tests.enabled` is `false` OR `workflow.tests.runBeforeShip` is `false`, skip this block (record `{ status: "skipped", reason: "pre-ship tests disabled" }` in the ship report and continue).
+
+### 2. Resolve the test command
+
+Same logic as `execute.md`'s `<test-integration>` block:
+
+- If `workflow.tests.command` is set, use it directly.
+- Otherwise auto-detect in priority order: `package.json scripts.test` → vitest → jest → `Cargo.toml` → `go.mod` → pytest. If none match, record `{ status: "skipped", reason: "no framework detected" }` and continue (do not block ship).
+
+### 3. Run the full suite
+
+Run the resolved command from the project root with timeout `workflow.tests.timeoutSeconds` (default 300). Unlike phase tests, this is the **full** suite — do not pass any phase-scoped filters.
+
+### 4. Parse and report
+
+Parse output using the same patterns described in `<test-integration>`. Surface a `testResults` block in the ship report:
+
+```typescript
+testResults: {
+  framework: string;
+  command: string;
+  passed: number;
+  failed: number;
+  skipped: number;
+  durationMs: number;
+  status: "passed" | "failed" | "skipped";
+}
+```
+
+### 5. On test failure — halt and prompt
+
+If `testResults.status === "failed"`, **do not commit**. Surface the failing test output (last ~50 lines) and present an `AskUserQuestion`:
+
+- question: "Pre-ship tests failed. How would you like to proceed?"
+- options:
+  - label: "Pause to fix tests (Recommended)"
+    description: "Stop the ship and fix the failing tests before committing"
+  - label: "Skip tests and ship anyway"
+    description: "Proceed with commit despite failing tests (risky)"
+  - label: "Abort ship"
+    description: "Cancel the ship operation entirely"
+
+Behavior by choice:
+- **Pause**: Set work `status` to `"paused"`, leave `pipelineStep` as `"SHIP"`, and exit. User fixes tests and re-runs `/tiki:ship`.
+- **Skip and ship anyway**: Continue to commit. Note the override in the commit body and the GitHub close comment.
+- **Abort**: Set work `status` back to `"executing"` and exit without committing.
+</pre-ship-tests>
 
 <commit-format>
 Generate a commit message following this format:

--- a/packages/framework/commands/execute.md
+++ b/packages/framework/commands/execute.md
@@ -17,11 +17,12 @@ Execute the phases of a planned issue. Each phase runs with focused context, pro
     1. Display phase details (title, files, verification criteria)
     2. Execute the phase content (the actual work)
     3. Run verification checks
-    4. Generate a summary of what was accomplished
-    5. Update phase status and save state
+    4. Run test integration (see `<test-integration>` block) before declaring verification passed
+    5. Generate a summary of what was accomplished (include `testResults` if tests ran)
+    6. Update phase status and save state
   </step>
   <step>If verification passes, advance to next phase or complete</step>
-  <step>If verification fails, offer recovery options</step>
+  <step>If verification fails (including test failures), surface details and offer recovery options</step>
 </instructions>
 
 <state-update-requirement>
@@ -242,6 +243,94 @@ During execution, update `.tiki/state.json`:
     - Pause execution
   </error>
 </errors>
+
+<test-integration>
+## Test Framework Integration
+
+After phase work completes, run the project's test suite as part of verification. Test results are surfaced in the phase summary as `testResults`.
+
+> Hook-based override is out of scope for v1; use `.tiki/config.json`.
+
+### 1. Read configuration
+
+Read `.tiki/config.json` and look for `workflow.tests`. Defaults if file/section is absent:
+
+```json
+{
+  "enabled": true,
+  "command": null,
+  "runOnEachPhase": false,
+  "runBeforeShip": true,
+  "timeoutSeconds": 300
+}
+```
+
+If `workflow.tests.enabled` is `false`, skip this block entirely (record `{ status: "skipped", reason: "tests disabled in config" }`).
+
+### 2. Decide whether to run
+
+Run tests for this phase only if **either** is true:
+- `workflow.tests.runOnEachPhase` is `true`, OR
+- The current phase's `verification` array explicitly mentions a test step — any entry whose lowercased text contains one of: `vitest`, `jest`, `pnpm test`, `npm test`, `cargo test`, `go test`, `pytest`, or the bare token `test` (word boundary).
+
+Otherwise, skip with `{ status: "skipped", reason: "phase verification does not require tests" }`.
+
+### 3. Resolve the test command
+
+If `workflow.tests.command` is set (non-null string), use it directly — this overrides detection.
+
+Otherwise, auto-detect by checking project files in this priority order:
+
+1. **`package.json` with `scripts.test`** → use `pnpm test` if `pnpm-lock.yaml` exists, else `npm test`
+2. **`package.json` with `vitest` in deps/devDeps** → `pnpm vitest run` (or `npx vitest run` if no pnpm lockfile)
+3. **`package.json` with `jest` in deps/devDeps** → `pnpm jest` (or `npx jest`)
+4. **`Cargo.toml` present** → `cargo test`
+5. **`go.mod` present** → `go test ./...`
+6. **`pytest.ini` OR `pyproject.toml` containing `[tool.pytest]` OR a `tests/` directory containing `.py` files** → `pytest`
+
+If none match, record `{ status: "skipped", reason: "no framework detected" }` and continue.
+
+### 4. Run
+
+Run the resolved command from the project root with a timeout of `workflow.tests.timeoutSeconds` (default 300). Capture stdout, stderr, exit code, and elapsed time.
+
+### 5. Parse output
+
+Best-effort grep the combined stdout/stderr for these patterns. Always set `framework` to the detected/configured framework name (`vitest`, `jest`, `pytest`, `cargo`, `go`, `npm`, `unknown`).
+
+- **vitest:** `Test Files  N passed`, `Tests  N passed` (also `failed`, `skipped`)
+- **jest:** `Tests:  N passed, N total` (also `failed`, `skipped`)
+- **pytest:** `N passed in N.NNs` (also `N failed`, `N skipped`)
+- **cargo:** `test result: ok. N passed; N failed` (also `N ignored`)
+- **go:** `PASS\nok ...` per package; `--json` output gives structured pass/fail counts (optional)
+
+If parsing fails, fall back to exit code: `0 → status: "passed"` with counts unknown, non-zero → `status: "failed"`.
+
+### 6. Surface in phase summary
+
+Add a `testResults` field to the phase summary:
+
+```typescript
+testResults: {
+  framework: string;       // "vitest" | "jest" | "pytest" | "cargo" | "go" | "npm" | "unknown"
+  command: string;         // the command actually run
+  passed: number;          // 0 if unknown
+  failed: number;
+  skipped: number;
+  durationMs: number;
+  status: "passed" | "failed" | "skipped";
+}
+```
+
+### 7. On test failure
+
+If `testResults.status === "failed"`:
+1. Mark phase verification as failed.
+2. Include the failing test output (last ~50 lines of stdout/stderr) in the phase error output BEFORE falling through to the standard `verification-failed` recovery flow.
+3. Do not advance to the next phase.
+
+The recovery options under `<next-actions>` (Fix and retry / Skip / Pause / Heal) apply normally — auto-heal hooks (if installed by a future issue) can pick up `testResults` to drive repair.
+</test-integration>
 
 <next-actions>
 **After successful phase:**

--- a/packages/framework/commands/ship.md
+++ b/packages/framework/commands/ship.md
@@ -18,6 +18,7 @@ Finalize an issue by committing changes, pushing to remote, and closing the GitH
     - Build succeeds
     - No uncommitted changes from unrelated work
   </step>
+  <step>Run the full test suite (see `<pre-ship-tests>` block) before committing. Halt and prompt the user if tests fail.</step>
   <step>Stage and commit changes with a descriptive message</step>
   <step>Push to remote</step>
   <step>Close the GitHub issue with a summary comment</step>
@@ -54,6 +55,72 @@ Before shipping, verify:
 - [ ] No unrelated changes mixed in
 - [ ] Working directory is clean after commit
 </pre-ship-verification>
+
+<pre-ship-tests>
+## Pre-Ship Test Run
+
+Before staging and committing, run the full project test suite. This catches regressions that phase-level verification may have missed.
+
+### 1. Read configuration
+
+Read `.tiki/config.json` and look for `workflow.tests`. Defaults if file/section is absent:
+
+```json
+{
+  "enabled": true,
+  "command": null,
+  "runBeforeShip": true,
+  "timeoutSeconds": 300
+}
+```
+
+If `workflow.tests.enabled` is `false` OR `workflow.tests.runBeforeShip` is `false`, skip this block (record `{ status: "skipped", reason: "pre-ship tests disabled" }` in the ship report and continue).
+
+### 2. Resolve the test command
+
+Same logic as `execute.md`'s `<test-integration>` block:
+
+- If `workflow.tests.command` is set, use it directly.
+- Otherwise auto-detect in priority order: `package.json scripts.test` → vitest → jest → `Cargo.toml` → `go.mod` → pytest. If none match, record `{ status: "skipped", reason: "no framework detected" }` and continue (do not block ship).
+
+### 3. Run the full suite
+
+Run the resolved command from the project root with timeout `workflow.tests.timeoutSeconds` (default 300). Unlike phase tests, this is the **full** suite — do not pass any phase-scoped filters.
+
+### 4. Parse and report
+
+Parse output using the same patterns described in `<test-integration>`. Surface a `testResults` block in the ship report:
+
+```typescript
+testResults: {
+  framework: string;
+  command: string;
+  passed: number;
+  failed: number;
+  skipped: number;
+  durationMs: number;
+  status: "passed" | "failed" | "skipped";
+}
+```
+
+### 5. On test failure — halt and prompt
+
+If `testResults.status === "failed"`, **do not commit**. Surface the failing test output (last ~50 lines) and present an `AskUserQuestion`:
+
+- question: "Pre-ship tests failed. How would you like to proceed?"
+- options:
+  - label: "Pause to fix tests (Recommended)"
+    description: "Stop the ship and fix the failing tests before committing"
+  - label: "Skip tests and ship anyway"
+    description: "Proceed with commit despite failing tests (risky)"
+  - label: "Abort ship"
+    description: "Cancel the ship operation entirely"
+
+Behavior by choice:
+- **Pause**: Set work `status` to `"paused"`, leave `pipelineStep` as `"SHIP"`, and exit. User fixes tests and re-runs `/tiki:ship`.
+- **Skip and ship anyway**: Continue to commit. Note the override in the commit body and the GitHub close comment.
+- **Abort**: Set work `status` back to `"executing"` and exit without committing.
+</pre-ship-tests>
 
 <commit-format>
 Generate a commit message following this format:


### PR DESCRIPTION
## Summary

Resolves #100. Adds test framework detection and execution to the EXECUTE and SHIP steps, with results surfaced in phase summaries.

- `<test-integration>` block in `execute.md` describes detection priority (vitest > jest > pytest > cargo test > go test), config check, output parsing, test-result schema
- `<pre-ship-tests>` block in `ship.md` runs full test suite before commit; on failure presents skip/pause/abort menu
- New `workflow.tests` section in `.tiki/config.json` (enabled, command override, runOnEachPhase, runBeforeShip, timeoutSeconds)
- Hook-based override deferred to a follow-up
- Mirrors in `packages/framework/.claude/commands/tiki/` synced

## Cross-PR conflict warning

PR #101 (auto-healing) creates `.tiki/config.json` with a `workflow.autoHeal` section. This PR creates the same file with a `workflow.tests` section. **When both PRs merge, expect a conflict on `.tiki/config.json`** — the resolution is to keep both subsections:

```json
{ "workflow": { "tests": { ... }, "autoHeal": { ... } } }
```

## Test plan

- [ ] On a vitest project, run `/tiki:execute` on a phase whose `verification` array contains "test"; confirm vitest is detected and run, results parsed into testResults
- [ ] On a Cargo project, same test with `cargo test` detection
- [ ] With `workflow.tests.enabled: false`, execute does NOT run tests
- [ ] With `workflow.tests.command` override, that command is used instead of detection
- [ ] On `/tiki:ship`, full test suite runs before commit (when `runBeforeShip: true`)
- [ ] Test failure during ship presents skip/pause/abort menu
- [ ] `pnpm build` passes

Part of release v0.2.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)