### PR TITLE
feat: parallel phase execution (#99)

### DIFF
--- a/.tiki/plans/issue-99.json
+++ b/.tiki/plans/issue-99.json
@@ -1,0 +1,111 @@
+{
+  "schemaVersion": 1,
+  "issue": {
+    "number": 99,
+    "title": "Parallel phase execution",
+    "url": "https://github.com/Eric-Ness/Tiki-V2/issues/99"
+  },
+  "createdAt": "2026-05-08T00:00:00.000Z",
+  "successCriteria": [
+    { "id": "SC1", "category": "framework", "description": "execute.md describes a deterministic algorithm for grouping phases into parallelizable batches using Kahn's algorithm by levels and file-conflict-free greedy splits" },
+    { "id": "SC2", "category": "framework", "description": "execute.md instructs Claude to dispatch parallel phases via multiple Agent (Task) tool calls in a single assistant message" },
+    { "id": "SC3", "category": "framework", "description": "execute.md specifies state.json updates: setting parallelExecution when starting a group, appending to completedInGroup as phases finish, clearing it when the group completes" },
+    { "id": "SC4", "category": "framework", "description": "execute.md describes failure handling: in-flight sub-agents are not cancelled; failures are surfaced together once all return" },
+    { "id": "SC5", "category": "framework", "description": "execute.md preserves backward compatibility: a single phase at a level runs without parallelExecution being set" },
+    { "id": "SC6", "category": "schema", "description": "Rust IssueContext exposes an optional parallelExecution field with phases, completedInGroup, totalInGroup, startedAt that round-trips through serde with backward-compat (#[serde(default)])" },
+    { "id": "SC7", "category": "ui", "description": "Desktop app shows a 'parallel: N' badge near the phase progress indicator when parallelExecution.phases.length > 1" },
+    { "id": "SC8", "category": "ui", "description": "Desktop TypeScript types (IssueContext in WorkCard.tsx and any mirroring locations) include the optional parallelExecution field" },
+    { "id": "SC9", "category": "build", "description": "pnpm build and cargo check (in apps/desktop/src-tauri) both pass cleanly after all changes" },
+    { "id": "SC10", "category": "framework", "description": "execute.md mirror file at packages/framework/.claude/commands/tiki/execute.md is byte-for-byte identical to the source" }
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "title": "Add <parallel-execution> block to execute.md (source + mirror)",
+      "status": "pending",
+      "content": "Add a new <parallel-execution> XML block to packages/framework/commands/execute.md, placed immediately after the <state-update-requirement> block and before <phase-execution>. Then byte-for-byte copy the result to packages/framework/.claude/commands/tiki/execute.md.\n\nThe block MUST cover:\n\n1. **When to parallelize**: Always, by default. Mention .tiki/config.json `workflow.parallel.enabled` (default true) as an opt-out hook.\n\n2. **Grouping algorithm** (deterministic):\n   a. Build adjacency from each phase's `dependencies: number[]`.\n   b. Compute topological levels: level 0 = phases whose dependencies are all in earlier (lower-index) levels or empty. Iterate until all phases assigned.\n   c. Within each level, partition phases into file-conflict-free groups using a greedy split:\n      - Start a new group with the first remaining phase.\n      - For each other remaining phase in the level, add it to the current group ONLY IF its `files` array has no overlap (set intersection) with any existing group member's `files` array.\n      - Phases that conflict become seeds of subsequent groups within the same level.\n   d. Each GROUP runs in parallel; groups within a level run sequentially; levels run sequentially.\n   e. If a phase has `files: []` (or missing), treat it as conflicting with everything (be conservative — run alone).\n\n3. **Dispatch mechanism**: When a parallel group has 2+ phases, Claude dispatches them in a SINGLE assistant message containing multiple Task tool calls (one per phase). The Anthropic Agent tool runs these concurrently when invoked together. When a group has only 1 phase, dispatch it as a single Task call (or run inline as today).\n\n4. **State updates**:\n   - Starting a parallel group (size >= 2):\n     ```json\n     \"phase\": { \"current\": <max phase# in group>, \"total\": <total phases>, \"status\": \"executing\" },\n     \"parallelExecution\": {\n       \"phases\": [<phase numbers in group>],\n       \"completedInGroup\": [],\n       \"totalInGroup\": <group size>,\n       \"startedAt\": \"<ISO timestamp>\"\n     }\n     ```\n   - As each phase in the group completes, append its number to `completedInGroup`.\n   - When all phases in the group are done, CLEAR `parallelExecution` (omit or set to null) and advance.\n   - For single-phase levels/groups, do NOT set `parallelExecution` — only update `phase` (backward compatible).\n\n5. **Failure handling**: If a sub-agent fails while siblings are still running, do NOT attempt to cancel siblings — they're in flight. Wait for all to return. Then surface ALL failures together. Mark each failed phase status individually in the plan file. Trigger manual recovery (audit, retry, skip) once all sub-agents return.\n\n6. **Backward compatibility**: When the next level has only one phase, run sequentially (no parallelExecution). Old desktop clients reading state.json will see `phase` populated as before; the optional `parallelExecution` is ignored if unrecognized.\n\nVERIFY identical: `diff -q packages/framework/commands/execute.md packages/framework/.claude/commands/tiki/execute.md` returns no output.",
+      "verification": [
+        "<parallel-execution> block exists in packages/framework/commands/execute.md immediately before <phase-execution>",
+        "Block describes Kahn's-by-levels + file-conflict greedy split algorithm explicitly",
+        "Block describes single-message multi-Task dispatch as the parallelism mechanism",
+        "Block specifies parallelExecution state shape with phases, completedInGroup, totalInGroup, startedAt",
+        "Block describes failure handling (no cancellation, surface failures together)",
+        "Mirror file is byte-for-byte identical: diff -q against source returns no output"
+      ],
+      "addressesCriteria": ["SC1", "SC2", "SC3", "SC4", "SC5", "SC10"],
+      "files": [
+        "packages/framework/commands/execute.md",
+        "packages/framework/.claude/commands/tiki/execute.md"
+      ],
+      "dependencies": []
+    },
+    {
+      "number": 2,
+      "title": "Add ParallelExecution struct to Rust state.rs",
+      "status": "pending",
+      "content": "Extend apps/desktop/src-tauri/src/state.rs to support the optional parallelExecution field on IssueContext.\n\n### Add a new struct\n\n```rust\n/// Parallel execution tracking (optional, present only during parallel phase groups)\n#[derive(Debug, Clone, Serialize, Deserialize)]\n#[serde(rename_all = \"camelCase\")]\npub struct ParallelExecution {\n    /// Phase numbers currently running in parallel\n    pub phases: Vec<u32>,\n    /// Phase numbers in this group that have already completed\n    #[serde(default)]\n    pub completed_in_group: Vec<u32>,\n    /// Total phases in this parallel group (for progress display)\n    pub total_in_group: u32,\n    /// ISO timestamp when the group started\n    pub started_at: String,\n}\n```\n\nPlace it near `PhaseProgress` (line ~330).\n\n### Wire into IssueContext\n\nIn `IssueContext` (around line 36), add:\n\n```rust\n#[serde(default, skip_serializing_if = \"Option::is_none\")]\npub parallel_execution: Option<ParallelExecution>,\n```\n\nPlace it adjacent to `phase`.\n\n### Update RawIssueContext\n\nAdd matching field to the deserializer helper (around line 62):\n\n```rust\n#[serde(default)]\nparallel_execution: Option<ParallelExecution>,\n```\n\n### Update the IssueContext::deserialize impl\n\nIn the final `Ok(IssueContext { ... })` block (around line 279), pass the field through:\n\n```rust\nparallel_execution: raw.parallel_execution,\n```\n\nThe `#[serde(default)]` on the raw field ensures missing/old state.json files still parse cleanly.\n\n### Verify\n\n```powershell\ncd C:\\Users\\ericn\\Documents\\Github\\Tiki-V2\\apps\\desktop\\src-tauri; cargo check\n```",
+      "verification": [
+        "ParallelExecution struct exists in state.rs with phases, completed_in_group, total_in_group, started_at fields",
+        "ParallelExecution serde renames match camelCase JSON contract (completedInGroup, totalInGroup, startedAt)",
+        "IssueContext has parallel_execution: Option<ParallelExecution> with #[serde(default, skip_serializing_if = \"Option::is_none\")]",
+        "RawIssueContext has matching #[serde(default)] field and the deserialize impl threads it through",
+        "cargo check in apps/desktop/src-tauri passes with no errors"
+      ],
+      "addressesCriteria": ["SC6"],
+      "files": ["apps/desktop/src-tauri/src/state.rs"],
+      "dependencies": []
+    },
+    {
+      "number": 3,
+      "title": "Update desktop TS types and add ParallelBadge UI",
+      "status": "pending",
+      "content": "Update the desktop frontend so it can render parallel phase indicators.\n\n### TypeScript type changes\n\n**apps/desktop/src/components/work/WorkCard.tsx** (canonical IssueContext for the desktop app):\n\n1. Add an interface near `PhaseInfo`:\n\n```ts\nexport interface ParallelExecutionInfo {\n  phases: number[];\n  completedInGroup: number[];\n  totalInGroup: number;\n  startedAt: string;\n}\n```\n\n2. Add to `IssueContext`:\n\n```ts\nparallelExecution?: ParallelExecutionInfo;\n```\n\n3. In the existing `WorkCard` body, wherever the `phase.current / phase.total` text is rendered, add an inline parallel badge when `work.parallelExecution && work.parallelExecution.phases.length > 1`. Render it next to the existing 'Phase X of Y' text:\n\n```tsx\n{work.parallelExecution && work.parallelExecution.phases.length > 1 && (\n  <span className=\"parallel-badge\" title={`Phases ${work.parallelExecution.phases.join(', ')} running in parallel`}>\n    parallel: {work.parallelExecution.phases.length}\n  </span>\n)}\n```\n\n**apps/desktop/src/components/sidebar/WorkProgressCard.tsx**: this component already imports `WorkContext` from `WorkCard`, so the type flows automatically. Render the same `parallel-badge` next to `Phase {currentPhase}/{totalPhases}` inside `<span className=\"work-progress-text\">`. Read via `isIssue ? work.parallelExecution : undefined`.\n\n**apps/desktop/src/components/detail/IssueDetail.tsx**: the local `WorkContext` interface (lines ~14-24) is hand-rolled. Add to it:\n\n```ts\nparallelExecution?: {\n  phases: number[];\n  completedInGroup?: number[];\n  totalInGroup?: number;\n  startedAt?: string;\n};\n```\n\nNo UI rendering required in IssueDetail beyond keeping the type valid.\n\n**apps/desktop/src/stores/tikiStateStore.ts**: imports WorkContext from `../components/work` — no change needed.\n\n**apps/desktop/src/App.tsx**: uses WorkContext from work components — no change to TikiState needed.\n\n**apps/desktop/src/components/kanban/KanbanBoard.tsx**: uses an inline `{ phase?: ... }` cast — no change needed since it doesn't read parallelExecution.\n\n**apps/desktop/src/components/sidebar/IssuesSection.tsx**: same — inline cast, no change needed.\n\n### CSS\n\nAppend a `.parallel-badge` rule to **apps/desktop/src/components/sidebar/WorkProgressCard.css** (and a matching one near the existing `.work-card` styles in App.css if `WorkCard` uses App.css). Reuse existing color vars:\n\n```css\n.parallel-badge {\n  display: inline-block;\n  margin-left: 8px;\n  padding: 1px 6px;\n  border-radius: 8px;\n  background: rgba(96, 165, 250, 0.18);\n  color: #60a5fa;\n  font-size: 10px;\n  font-weight: 600;\n  font-family: var(--font-mono, monospace);\n  letter-spacing: 0.02em;\n  vertical-align: middle;\n}\n```\n\n### Update shared types (defensive)\n\nFor symmetry with Rust and to avoid drift, also extend **packages/shared/src/types/state.ts**:\n\n```ts\n/** Parallel execution tracking (optional, present only during parallel phase groups) */\nexport interface ParallelExecution {\n  phases: number[];\n  completedInGroup: number[];\n  totalInGroup: number;\n  startedAt: Timestamp;\n}\n```\n\nAdd to `IssueWork` and `ReleaseWork`:\n\n```ts\n/** Parallel execution group tracking (set only when phases > 1 are running concurrently) */\nparallelExecution?: ParallelExecution;\n```\n\nAlso add the field to **packages/shared/schemas/state.schema.json** under `issueWork.properties` and `releaseWork.properties`:\n\n```json\n\"parallelExecution\": {\n  \"type\": \"object\",\n  \"description\": \"Parallel execution tracking (set only during multi-phase parallel groups)\",\n  \"additionalProperties\": false,\n  \"properties\": {\n    \"phases\": { \"type\": \"array\", \"items\": { \"type\": \"integer\", \"minimum\": 1 } },\n    \"completedInGroup\": { \"type\": \"array\", \"items\": { \"type\": \"integer\", \"minimum\": 1 } },\n    \"totalInGroup\": { \"type\": \"integer\", \"minimum\": 1 },\n    \"startedAt\": { \"$ref\": \"#/$defs/timestamp\" }\n  },\n  \"required\": [\"phases\", \"totalInGroup\", \"startedAt\"]\n}\n```",
+      "verification": [
+        "WorkCard.tsx exports ParallelExecutionInfo and IssueContext.parallelExecution is optional",
+        "WorkCard renders a .parallel-badge when parallelExecution.phases.length > 1",
+        "WorkProgressCard.tsx renders .parallel-badge inside .work-progress-text when applicable",
+        "IssueDetail.tsx local WorkContext includes optional parallelExecution",
+        ".parallel-badge CSS rule exists in WorkProgressCard.css",
+        "packages/shared/src/types/state.ts exports ParallelExecution and adds optional parallelExecution to IssueWork and ReleaseWork",
+        "packages/shared/schemas/state.schema.json includes parallelExecution under issueWork properties",
+        "pnpm build from repo root passes with no TypeScript errors"
+      ],
+      "addressesCriteria": ["SC7", "SC8"],
+      "files": [
+        "apps/desktop/src/components/work/WorkCard.tsx",
+        "apps/desktop/src/components/sidebar/WorkProgressCard.tsx",
+        "apps/desktop/src/components/sidebar/WorkProgressCard.css",
+        "apps/desktop/src/components/detail/IssueDetail.tsx",
+        "packages/shared/src/types/state.ts",
+        "packages/shared/schemas/state.schema.json"
+      ],
+      "dependencies": [2]
+    },
+    {
+      "number": 4,
+      "title": "Build verification and final integration check",
+      "status": "pending",
+      "content": "Final verification gate. Run both build chains end-to-end and capture failures.\n\n```powershell\ncd C:\\Users\\ericn\\Documents\\Github\\Tiki-V2; pnpm build 2>&1 | Select-Object -Last 20\ncd C:\\Users\\ericn\\Documents\\Github\\Tiki-V2\\apps\\desktop\\src-tauri; cargo check 2>&1 | Select-Object -Last 20\n```\n\nBoth must succeed. If `pnpm build` fails, look at WorkCard.tsx, WorkProgressCard.tsx, IssueDetail.tsx, and packages/shared/src/types/state.ts for type mismatches. If `cargo check` fails, look at state.rs serde derives and field placement.\n\nAlso verify the mirror file is byte-identical:\n\n```powershell\ndiff -q packages/framework/commands/execute.md packages/framework/.claude/commands/tiki/execute.md\n```\n\nIf there are differences, re-copy the source over the mirror.",
+      "verification": [
+        "pnpm build from repo root completes with exit code 0",
+        "cargo check in apps/desktop/src-tauri completes with exit code 0",
+        "diff between source and mirror execute.md returns no output (byte-identical)"
+      ],
+      "addressesCriteria": ["SC9", "SC10"],
+      "files": [],
+      "dependencies": [1, 2, 3]
+    }
+  ],
+  "coverageMatrix": {
+    "SC1": [1],
+    "SC2": [1],
+    "SC3": [1],
+    "SC4": [1],
+    "SC5": [1],
+    "SC6": [2],
+    "SC7": [3],
+    "SC8": [3],
+    "SC9": [4],
+    "SC10": [1, 4]
+  }
+}

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -42,6 +42,8 @@ pub struct IssueContext {
     pub pipeline_history: Option<Vec<PipelineStepRecord>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phase: Option<PhaseProgress>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel_execution: Option<ParallelExecution>,
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_activity: Option<String>,
@@ -78,6 +80,9 @@ struct RawIssueContext {
     // New format: flat phase progress (lenient: skip if unparseable)
     #[serde(default, deserialize_with = "deserialize_lenient_phase")]
     phase: Option<PhaseProgress>,
+    // Parallel phase execution group (optional, only set during multi-phase parallel groups)
+    #[serde(default)]
+    parallel_execution: Option<ParallelExecution>,
     // Old/array format: phases as object or array (lenient: skip if unparseable)
     #[serde(default, deserialize_with = "deserialize_lenient_phases")]
     phases: Option<RawPhasesVariant>,
@@ -282,6 +287,7 @@ impl<'de> Deserialize<'de> for IssueContext {
             pipeline_step: raw.pipeline_step,
             pipeline_history: raw.pipeline_history,
             phase,
+            parallel_execution: raw.parallel_execution,
             created_at,
             last_activity: raw.last_activity,
             audit_passed: raw.audit_passed,
@@ -333,6 +339,24 @@ pub struct PhaseProgress {
     pub total: u32,
     pub current: u32,
     pub status: PhaseProgressStatus,
+}
+
+/// Parallel execution tracking (optional, present only during multi-phase parallel groups).
+/// When this field is set on an IssueContext, multiple phases are running concurrently
+/// in separate sub-agents. When all phases in the group complete, this field is cleared
+/// and execution advances to the next group/level.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParallelExecution {
+    /// Phase numbers currently running in parallel
+    pub phases: Vec<u32>,
+    /// Phase numbers in this group that have already completed
+    #[serde(default)]
+    pub completed_in_group: Vec<u32>,
+    /// Total phases in this parallel group (for progress display)
+    pub total_in_group: u32,
+    /// ISO timestamp when the group started
+    pub started_at: String,
 }
 
 /// Status of the current phase

--- a/apps/desktop/src/components/detail/IssueDetail.tsx
+++ b/apps/desktop/src/components/detail/IssueDetail.tsx
@@ -19,6 +19,12 @@ interface WorkContext {
     total?: number;
     status?: string;
   };
+  parallelExecution?: {
+    phases: number[];
+    completedInGroup?: number[];
+    totalInGroup?: number;
+    startedAt?: string;
+  };
   createdAt?: string;
   lastActivity?: string;
 }

--- a/apps/desktop/src/components/sidebar/WorkProgressCard.css
+++ b/apps/desktop/src/components/sidebar/WorkProgressCard.css
@@ -189,6 +189,22 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* Parallel-execution badge — shown when multiple phases run concurrently */
+.parallel-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: rgba(96, 165, 250, 0.18);
+  color: #60a5fa;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--font-mono, monospace);
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
 /* Release progress */
 .work-progress-release {
   display: flex;

--- a/apps/desktop/src/components/sidebar/WorkProgressCard.tsx
+++ b/apps/desktop/src/components/sidebar/WorkProgressCard.tsx
@@ -84,6 +84,10 @@ export function WorkProgressCard({ work, workId, isStale }: WorkProgressCardProp
   const currentPhase = phase?.current || 0;
   const phaseStatus = phase?.status || "pending";
 
+  // Parallel execution info — present only when a multi-phase group is in flight
+  const parallelExecution = isIssue ? work.parallelExecution : undefined;
+  const isParallel = !!parallelExecution && parallelExecution.phases.length > 1;
+
   // Show phase progress when we have phases (during EXECUTE or any phase-based work)
   const showPhaseProgress = phase && totalPhases > 0;
 
@@ -153,6 +157,14 @@ export function WorkProgressCard({ work, workId, isStale }: WorkProgressCardProp
           </div>
           <span className="work-progress-text">
             Phase {currentPhase}/{totalPhases}
+            {isParallel && parallelExecution && (
+              <span
+                className="parallel-badge"
+                title={`Phases ${parallelExecution.phases.join(", ")} running in parallel`}
+              >
+                parallel: {parallelExecution.phases.length}
+              </span>
+            )}
             {liveTimer && <span className="work-progress-timer"> {liveTimer}</span>}
             {!liveTimer && totalDuration > 0 && (
               <span className="work-progress-total-duration"> ({formatDuration(totalDuration)})</span>

--- a/apps/desktop/src/components/work/WorkCard.tsx
+++ b/apps/desktop/src/components/work/WorkCard.tsx
@@ -8,6 +8,22 @@ export interface PhaseInfo {
   status: PhaseStatus;
 }
 
+/**
+ * Parallel execution tracking — present only when multiple phases are running concurrently.
+ * When set, sub-agents are dispatched for each phase in `phases`; once all return, the
+ * parent clears this field and advances to the next group.
+ */
+export interface ParallelExecutionInfo {
+  /** Phase numbers currently running in parallel */
+  phases: number[];
+  /** Phase numbers in this group that have already completed */
+  completedInGroup: number[];
+  /** Total phases in this parallel group (for progress display) */
+  totalInGroup: number;
+  /** ISO timestamp when the group started */
+  startedAt: string;
+}
+
 export interface PipelineStepRecord {
   step: PipelineStep;
   startedAt: string;
@@ -25,6 +41,8 @@ export interface IssueContext {
   pipelineStep?: PipelineStep;
   pipelineHistory?: PipelineStepRecord[];
   phase?: PhaseInfo;
+  /** Set only while a multi-phase parallel group is in flight; cleared when group completes */
+  parallelExecution?: ParallelExecutionInfo;
   createdAt: string;
   lastActivity?: string;
   auditPassed?: boolean;
@@ -85,6 +103,14 @@ export function WorkCard({ work }: WorkCardProps) {
           </div>
           <span className="progress-text">
             Phase {work.phase.current} of {work.phase.total}
+            {work.parallelExecution && work.parallelExecution.phases.length > 1 && (
+              <span
+                className="parallel-badge"
+                title={`Phases ${work.parallelExecution.phases.join(", ")} running in parallel`}
+              >
+                parallel: {work.parallelExecution.phases.length}
+              </span>
+            )}
           </span>
         </div>
       )}

--- a/apps/desktop/src/components/work/index.ts
+++ b/apps/desktop/src/components/work/index.ts
@@ -6,6 +6,7 @@ export type {
   WorkStatus,
   PhaseStatus,
   PhaseInfo,
+  ParallelExecutionInfo,
   PipelineStep,
   PipelineStepRecord
 } from "./WorkCard";

--- a/packages/framework/.claude/commands/tiki/execute.md
+++ b/packages/framework/.claude/commands/tiki/execute.md
@@ -75,6 +75,142 @@ This is not optional. The desktop app and other tooling rely on the `phase` obje
 ```
 </state-update-requirement>
 
+<parallel-execution>
+## Parallel Phase Execution
+
+Phases that have no shared file conflicts and whose dependencies are already satisfied can run concurrently in separate sub-agents. This section is the authoritative algorithm — follow it deterministically.
+
+### When to parallelize
+
+- **Default: ON.** Always attempt to parallelize independent phases.
+- **Opt-out hook:** Read `.tiki/config.json`. If `workflow.parallel.enabled === false`, fall back to fully sequential execution. If the file or key is missing, treat it as `true`.
+- **Edge case:** If a single-phase group emerges, run it as a single (non-parallel) phase using the existing single-phase code path. Do NOT set `parallelExecution`.
+
+### Step 1 — Build the dependency graph
+
+For each phase in the plan:
+- `node = phase.number`
+- `incoming edges = phase.dependencies` (numbers of phases that must complete first)
+- `files = phase.files || []`
+
+### Step 2 — Compute topological levels (Kahn's by levels)
+
+```
+remaining = set of all phase numbers
+levels = []
+while remaining is non-empty:
+    ready = [p for p in remaining if all of p.dependencies are NOT in remaining]
+    if ready is empty: ERROR — cycle in dependencies. Abort and surface.
+    levels.append(ready)
+    remaining -= ready
+```
+
+After this loop:
+- `levels[0]` = phases with no unsatisfied deps
+- `levels[i]` = phases whose deps are all in `levels[0..i-1]`
+- Levels run **sequentially**: do not start level `i+1` until every phase in level `i` is `completed`.
+
+### Step 3 — Within each level, split into file-conflict-free groups (greedy)
+
+Within a single level, two phases can run in the same parallel group iff their `files` arrays have an empty intersection (set difference). Use this greedy algorithm:
+
+```
+groups = []
+remaining_at_level = list of phases at this level (preserve plan order)
+while remaining_at_level is non-empty:
+    seed = remaining_at_level.pop_front()
+    group = [seed]
+    group_files = set(seed.files)
+    leftover = []
+    for p in remaining_at_level:
+        if set(p.files).intersection(group_files) is empty:
+            group.append(p)
+            group_files = group_files.union(p.files)
+        else:
+            leftover.append(p)
+    groups.append(group)
+    remaining_at_level = leftover
+```
+
+Conservative rules:
+- If `phase.files` is missing, empty, or null, treat the phase as conflicting with everything (assume worst case: it touches anything). Place it in its own group.
+- **Groups within a level run sequentially.** Levels run sequentially.
+- **Phases within a group run in parallel.**
+
+### Step 4 — Dispatch the group
+
+This is the parallelism mechanism. The Anthropic Agent (Task) tool runs concurrently when **multiple Task calls are emitted in a single assistant message**.
+
+- **Group size 1:** Run as a normal single phase (existing single-phase code path). Do NOT set `parallelExecution`.
+- **Group size N >= 2:** In ONE assistant message, emit N `Task` tool calls (one per phase in the group). Each Task uses `subagent_type: "general-purpose"` and the prompt template from `<sub-agent-protocol>` below. Each prompt MUST include the phase's files list and verification criteria so the sub-agent stays scoped to its files.
+
+### Step 5 — State updates (`.tiki/state.json`)
+
+**When starting a parallel group (size >= 2):** before dispatching the Task calls, write:
+
+```json
+"phase": {
+  "current": <max(phase.number for phase in group)>,
+  "total": <total phases in plan>,
+  "status": "executing"
+},
+"parallelExecution": {
+  "phases": [<all phase numbers in group, ascending>],
+  "completedInGroup": [],
+  "totalInGroup": <group size>,
+  "startedAt": "<current ISO timestamp>"
+}
+```
+
+`phase.current = max(...)` so old desktop clients that only read `phase` see a sensible "Phase X of Y" display while the group is in flight.
+
+**As each phase in the group returns:**
+- Append its number to `parallelExecution.completedInGroup` (or move to `failed` tracking if it failed).
+- Update the per-phase status in `.tiki/plans/issue-N.json` immediately (don't batch — the file watcher relies on this).
+- Do NOT advance `phase.current` while siblings are still running.
+
+**When all phases in the group have returned:**
+- Remove the `parallelExecution` field entirely (omit on serialize, or set to `null`).
+- If any phase failed, see Failure Handling below.
+- Otherwise, advance to the next group/level. If the next batch is also a parallel group of size >= 2, repeat from Step 4. If it's size 1, run sequentially without `parallelExecution`.
+
+**When the entire plan is done:** set work `status` to `"shipping"` and clear `phase.status` to `"completed"`.
+
+### Step 6 — Failure handling
+
+When at least one sub-agent in a parallel group fails:
+
+- **Do NOT cancel sibling sub-agents.** They are already in flight; cancellation is unsupported by the Agent tool and would only waste work. Let them run to completion.
+- **Wait for all sub-agents to return.** Collect every result.
+- **Surface all failures together.** Update the plan file: each failed phase gets `status: "failed"` with its error message. Successful siblings get `status: "completed"`.
+- **Pause for manual recovery.** Set work `status` to `"failed"`, clear `parallelExecution`, and present the recovery options from `<next-actions>` (fix and retry, skip, pause, heal). Do NOT auto-advance to the next level.
+
+### Step 7 — Backward compatibility
+
+- A single-phase level emits a single Task call (or runs inline) and DOES NOT set `parallelExecution`. Old clients see the familiar `phase: { current, total, status }` and behave identically.
+- Old state.json files lacking `parallelExecution` deserialize cleanly (the field is `Option<…>` with `#[serde(default)]` on the Rust side and optional in TypeScript).
+- The whole feature degrades gracefully: if every level happens to contain phases that all conflict on files, the algorithm collapses to one phase per group, which is byte-identical to sequential execution.
+
+### Worked example
+
+Plan with 5 phases:
+- P1: deps=[],     files=["a.rs"]
+- P2: deps=[],     files=["b.ts"]
+- P3: deps=[],     files=["a.rs"]   <-- conflicts with P1
+- P4: deps=[1,2],  files=["c.css"]
+- P5: deps=[3],    files=["a.rs"]
+
+Levels:
+- L0 = [P1, P2, P3]   (no deps)
+- L1 = [P4, P5]       (deps satisfied by L0)
+
+Groups:
+- L0 split: seed P1 (files=a.rs). P2 (b.ts) joins (no overlap) → group=[P1,P2]. P3 (a.rs) conflicts with P1 → next group=[P3]. So L0 runs as: parallel{P1,P2} → then P3.
+- L1 split: seed P4 (c.css). P5 (a.rs) has no overlap → group=[P4,P5]. So L1 runs as: parallel{P4,P5}.
+
+Final execution order: parallel{P1,P2} → P3 → parallel{P4,P5}.
+</parallel-execution>
+
 <phase-execution>
 **Before starting a phase:**
 1. Read the phase content from the plan

--- a/packages/framework/commands/execute.md
+++ b/packages/framework/commands/execute.md
@@ -75,6 +75,142 @@ This is not optional. The desktop app and other tooling rely on the `phase` obje
 ```
 </state-update-requirement>
 
+<parallel-execution>
+## Parallel Phase Execution
+
+Phases that have no shared file conflicts and whose dependencies are already satisfied can run concurrently in separate sub-agents. This section is the authoritative algorithm — follow it deterministically.
+
+### When to parallelize
+
+- **Default: ON.** Always attempt to parallelize independent phases.
+- **Opt-out hook:** Read `.tiki/config.json`. If `workflow.parallel.enabled === false`, fall back to fully sequential execution. If the file or key is missing, treat it as `true`.
+- **Edge case:** If a single-phase group emerges, run it as a single (non-parallel) phase using the existing single-phase code path. Do NOT set `parallelExecution`.
+
+### Step 1 — Build the dependency graph
+
+For each phase in the plan:
+- `node = phase.number`
+- `incoming edges = phase.dependencies` (numbers of phases that must complete first)
+- `files = phase.files || []`
+
+### Step 2 — Compute topological levels (Kahn's by levels)
+
+```
+remaining = set of all phase numbers
+levels = []
+while remaining is non-empty:
+    ready = [p for p in remaining if all of p.dependencies are NOT in remaining]
+    if ready is empty: ERROR — cycle in dependencies. Abort and surface.
+    levels.append(ready)
+    remaining -= ready
+```
+
+After this loop:
+- `levels[0]` = phases with no unsatisfied deps
+- `levels[i]` = phases whose deps are all in `levels[0..i-1]`
+- Levels run **sequentially**: do not start level `i+1` until every phase in level `i` is `completed`.
+
+### Step 3 — Within each level, split into file-conflict-free groups (greedy)
+
+Within a single level, two phases can run in the same parallel group iff their `files` arrays have an empty intersection (set difference). Use this greedy algorithm:
+
+```
+groups = []
+remaining_at_level = list of phases at this level (preserve plan order)
+while remaining_at_level is non-empty:
+    seed = remaining_at_level.pop_front()
+    group = [seed]
+    group_files = set(seed.files)
+    leftover = []
+    for p in remaining_at_level:
+        if set(p.files).intersection(group_files) is empty:
+            group.append(p)
+            group_files = group_files.union(p.files)
+        else:
+            leftover.append(p)
+    groups.append(group)
+    remaining_at_level = leftover
+```
+
+Conservative rules:
+- If `phase.files` is missing, empty, or null, treat the phase as conflicting with everything (assume worst case: it touches anything). Place it in its own group.
+- **Groups within a level run sequentially.** Levels run sequentially.
+- **Phases within a group run in parallel.**
+
+### Step 4 — Dispatch the group
+
+This is the parallelism mechanism. The Anthropic Agent (Task) tool runs concurrently when **multiple Task calls are emitted in a single assistant message**.
+
+- **Group size 1:** Run as a normal single phase (existing single-phase code path). Do NOT set `parallelExecution`.
+- **Group size N >= 2:** In ONE assistant message, emit N `Task` tool calls (one per phase in the group). Each Task uses `subagent_type: "general-purpose"` and the prompt template from `<sub-agent-protocol>` below. Each prompt MUST include the phase's files list and verification criteria so the sub-agent stays scoped to its files.
+
+### Step 5 — State updates (`.tiki/state.json`)
+
+**When starting a parallel group (size >= 2):** before dispatching the Task calls, write:
+
+```json
+"phase": {
+  "current": <max(phase.number for phase in group)>,
+  "total": <total phases in plan>,
+  "status": "executing"
+},
+"parallelExecution": {
+  "phases": [<all phase numbers in group, ascending>],
+  "completedInGroup": [],
+  "totalInGroup": <group size>,
+  "startedAt": "<current ISO timestamp>"
+}
+```
+
+`phase.current = max(...)` so old desktop clients that only read `phase` see a sensible "Phase X of Y" display while the group is in flight.
+
+**As each phase in the group returns:**
+- Append its number to `parallelExecution.completedInGroup` (or move to `failed` tracking if it failed).
+- Update the per-phase status in `.tiki/plans/issue-N.json` immediately (don't batch — the file watcher relies on this).
+- Do NOT advance `phase.current` while siblings are still running.
+
+**When all phases in the group have returned:**
+- Remove the `parallelExecution` field entirely (omit on serialize, or set to `null`).
+- If any phase failed, see Failure Handling below.
+- Otherwise, advance to the next group/level. If the next batch is also a parallel group of size >= 2, repeat from Step 4. If it's size 1, run sequentially without `parallelExecution`.
+
+**When the entire plan is done:** set work `status` to `"shipping"` and clear `phase.status` to `"completed"`.
+
+### Step 6 — Failure handling
+
+When at least one sub-agent in a parallel group fails:
+
+- **Do NOT cancel sibling sub-agents.** They are already in flight; cancellation is unsupported by the Agent tool and would only waste work. Let them run to completion.
+- **Wait for all sub-agents to return.** Collect every result.
+- **Surface all failures together.** Update the plan file: each failed phase gets `status: "failed"` with its error message. Successful siblings get `status: "completed"`.
+- **Pause for manual recovery.** Set work `status` to `"failed"`, clear `parallelExecution`, and present the recovery options from `<next-actions>` (fix and retry, skip, pause, heal). Do NOT auto-advance to the next level.
+
+### Step 7 — Backward compatibility
+
+- A single-phase level emits a single Task call (or runs inline) and DOES NOT set `parallelExecution`. Old clients see the familiar `phase: { current, total, status }` and behave identically.
+- Old state.json files lacking `parallelExecution` deserialize cleanly (the field is `Option<…>` with `#[serde(default)]` on the Rust side and optional in TypeScript).
+- The whole feature degrades gracefully: if every level happens to contain phases that all conflict on files, the algorithm collapses to one phase per group, which is byte-identical to sequential execution.
+
+### Worked example
+
+Plan with 5 phases:
+- P1: deps=[],     files=["a.rs"]
+- P2: deps=[],     files=["b.ts"]
+- P3: deps=[],     files=["a.rs"]   <-- conflicts with P1
+- P4: deps=[1,2],  files=["c.css"]
+- P5: deps=[3],    files=["a.rs"]
+
+Levels:
+- L0 = [P1, P2, P3]   (no deps)
+- L1 = [P4, P5]       (deps satisfied by L0)
+
+Groups:
+- L0 split: seed P1 (files=a.rs). P2 (b.ts) joins (no overlap) → group=[P1,P2]. P3 (a.rs) conflicts with P1 → next group=[P3]. So L0 runs as: parallel{P1,P2} → then P3.
+- L1 split: seed P4 (c.css). P5 (a.rs) has no overlap → group=[P4,P5]. So L1 runs as: parallel{P4,P5}.
+
+Final execution order: parallel{P1,P2} → P3 → parallel{P4,P5}.
+</parallel-execution>
+
 <phase-execution>
 **Before starting a phase:**
 1. Read the phase content from the plan

--- a/packages/shared/schemas/state.schema.json
+++ b/packages/shared/schemas/state.schema.json
@@ -158,6 +158,33 @@
             }
           }
         },
+        "parallelExecution": {
+          "type": "object",
+          "description": "Parallel execution group tracking — set only while multiple phases are running concurrently in separate sub-agents",
+          "additionalProperties": false,
+          "required": ["phases", "totalInGroup", "startedAt"],
+          "properties": {
+            "phases": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 },
+              "description": "Phase numbers currently running in parallel"
+            },
+            "completedInGroup": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 },
+              "description": "Phase numbers in this group that have already completed"
+            },
+            "totalInGroup": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Total phases in this parallel group (for progress display)"
+            },
+            "startedAt": {
+              "$ref": "#/$defs/timestamp",
+              "description": "ISO 8601 timestamp when the group started"
+            }
+          }
+        },
         "createdAt": {
           "$ref": "#/$defs/timestamp"
         },
@@ -268,6 +295,29 @@
             },
             "status": {
               "$ref": "#/$defs/phaseStatus"
+            }
+          }
+        },
+        "parallelExecution": {
+          "type": "object",
+          "description": "Parallel execution group tracking for the current issue — set only while multiple phases are running concurrently",
+          "additionalProperties": false,
+          "required": ["phases", "totalInGroup", "startedAt"],
+          "properties": {
+            "phases": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 }
+            },
+            "completedInGroup": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 }
+            },
+            "totalInGroup": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "startedAt": {
+              "$ref": "#/$defs/timestamp"
             }
           }
         },

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -10,6 +10,7 @@ export type {
   Timestamp,
   IssueInfo,
   PhaseProgress,
+  ParallelExecution,
   WorkError,
   IssueWork,
   ReleaseInfo,

--- a/packages/shared/src/types/state.ts
+++ b/packages/shared/src/types/state.ts
@@ -88,6 +88,22 @@ export interface PhaseProgress {
   status: PhaseStatus;
 }
 
+/**
+ * Parallel execution tracking — present only when multiple phases are running concurrently
+ * in separate sub-agents. When the group completes, this field is cleared and execution
+ * advances to the next group/level. Single-phase groups DO NOT set this field.
+ */
+export interface ParallelExecution {
+  /** Phase numbers currently running in parallel */
+  phases: number[];
+  /** Phase numbers in this group that have already completed */
+  completedInGroup: number[];
+  /** Total phases in this parallel group (for progress display) */
+  totalInGroup: number;
+  /** ISO 8601 timestamp when the group started */
+  startedAt: Timestamp;
+}
+
 /** Error details for failed work */
 export interface WorkError {
   message: string;
@@ -108,6 +124,8 @@ export interface IssueWork {
   /** History of pipeline step transitions with timing */
   pipelineHistory?: PipelineStepRecord[];
   phase?: PhaseProgress;
+  /** Parallel execution group tracking (set only while multiple phases are running concurrently) */
+  parallelExecution?: ParallelExecution;
   createdAt: Timestamp;
   lastActivity: Timestamp;
   error?: WorkError;
@@ -138,6 +156,8 @@ export interface ReleaseWork {
   pipelineStep?: PipelineStep;
   /** Current phase of current issue */
   phase?: PhaseProgress;
+  /** Parallel execution group tracking for the current issue (set only while multiple phases run concurrently) */
+  parallelExecution?: ParallelExecution;
   createdAt: Timestamp;
   lastActivity: Timestamp;
   error?: WorkError;


### PR DESCRIPTION
## Summary

Resolves #99. Enables concurrent execution of independent phases via single-message multi-Task sub-agent dispatch.

- `<parallel-execution>` block in `execute.md` describes Kahn's-by-levels topo grouping, greedy file-conflict split within each level, state-tracking shape, failure handling, and backward compatibility
- New optional `ParallelExecution` struct on `IssueContext` (Rust + TS) — `phases`, `completedInGroup`, `totalInGroup`, `startedAt`
- `#[serde(default, skip_serializing_if = "Option::is_none")]` keeps existing plans/state files backward compatible
- Desktop UI: small "(parallel: N)" badge in WorkCard and WorkProgressCard when more than one phase is running concurrently
- Canonical type in `@tiki/shared` keeps schema in sync
- Mirror in `packages/framework/.claude/commands/tiki/execute.md` synced

## Test plan

- [ ] Plan with two independent phases (no shared `dependencies`, no overlapping `files`) is executed: confirm both phases dispatch in a single assistant message and `parallelExecution` populates in state.json
- [ ] Plan with two phases sharing a file falls back to sequential execution
- [ ] Plan with single phase per level still uses single-phase tracking (no `parallelExecution`)
- [ ] Existing plans without parallel groupings continue to work unchanged
- [ ] Desktop sidebar shows "(parallel: N)" badge when group has 2+ phases
- [ ] `pnpm build` and `cargo check` pass

## Known follow-ups (out of scope)

- Resume semantics for paused parallel groups (which `completedInGroup` entries are authoritative on resume?)
- Summary aggregation across parallel groups for next-group sub-agent context

Part of release v0.2.17. Final issue in the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)