### PR TITLE
fix: stop double-paste in terminal — remove redundant Ctrl+V handlers (#155)

### DIFF
--- a/.tiki/plans/issue-155.json
+++ b/.tiki/plans/issue-155.json
@@ -1,0 +1,22 @@
+{
+  "issue": {
+    "number": 155,
+    "title": "Bug: Ctrl+V double-pastes in terminal — custom keydown handler and xterm native paste event both write to PTY"
+  },
+  "phases": [
+    {
+      "number": 1,
+      "title": "Delete redundant Ctrl+V and Ctrl+Shift+V handlers",
+      "content": "Remove the two custom paste branches in apps/desktop/src/components/terminal/Terminal.tsx (lines 255-273 in current HEAD): the Ctrl+Shift+V handler at 255-263 and the Ctrl+V handler at 265-273. Both call `xterm.paste(clipboardText)` after a custom `clipboard.readText()` call and return `false` from `attachCustomKeyEventHandler` — but xterm.js's own internal `paste` DOM event listener still fires independently, writing the same text a second time. Deleting both branches lets xterm.js's native paste path own paste exclusively. Keep the Ctrl+Shift+C copy branch (lines 247-253) — it is the only path for copy-on-Ctrl+Shift+C since xterm.js does not provide it. Update the section comment from \"Handle copy/paste keyboard shortcuts\" to \"Handle copy keyboard shortcut\" since paste is no longer handled here.",
+      "verification": [
+        "pnpm typecheck clean from repo root",
+        "pnpm build clean from repo root (uses tsc -b which is stricter than typecheck)",
+        "Manual smoke test in pnpm tauri:dev: paste a 200-character single line via Ctrl+V — appears exactly once",
+        "Paste a 5-line block via Ctrl+V — appears once, line endings preserved",
+        "Ctrl+Shift+V also pastes once (no longer doubled)",
+        "Ctrl+Shift+C still copies the selection (regression check)"
+      ],
+      "status": "pending"
+    }
+  ]
+}

--- a/.tiki/releases/v0.5.3.json
+++ b/.tiki/releases/v0.5.3.json
@@ -1,0 +1,37 @@
+{
+  "version": "v0.5.3",
+  "name": "Terminal polish",
+  "status": "pending",
+  "issues": [
+    {
+      "number": 155,
+      "title": "Bug: Ctrl+V double-pastes in terminal — custom keydown handler and xterm native paste event both write to PTY"
+    },
+    {
+      "number": 156,
+      "title": "Bug: Ctrl+W and Ctrl+T in terminal close/open Tiki tabs instead of going to the shell"
+    },
+    {
+      "number": 157,
+      "title": "Bug: PTY reader corrupts multi-byte UTF-8 across 4KB boundaries; also overloads IPC during Tab completion (E4)"
+    },
+    {
+      "number": 158,
+      "title": "Enhancement: Add 'Clear Scrollback' to terminal tab context menu + Ctrl+Shift+K shortcut (E1)"
+    },
+    {
+      "number": 159,
+      "title": "Enhancement: 'Resume Conversation' action when the last command in a terminal was 'claude'"
+    },
+    {
+      "number": 160,
+      "title": "Enhancement: Add Settings explainer that Ctrl+Z in the terminal is SIGTSTP, not editor undo"
+    },
+    {
+      "number": 161,
+      "title": "Tech debt: Migrate desktop app from legacy 'xterm' package to '@xterm/xterm' namespace"
+    }
+  ],
+  "createdAt": "2026-05-13T00:00:00.000Z",
+  "shipped": false
+}

--- a/.tiki/state.json
+++ b/.tiki/state.json
@@ -1,6 +1,45 @@
 {
   "schemaVersion": 1,
-  "activeWork": {},
+  "activeWork": {
+    "release:v0.5.3": {
+      "type": "release",
+      "release": {
+        "version": "v0.5.3",
+        "issues": [
+          155,
+          156,
+          157,
+          158,
+          159,
+          160,
+          161
+        ],
+        "currentIssue": 155,
+        "completedIssues": []
+      },
+      "status": "executing",
+      "pipelineStep": "EXECUTE",
+      "createdAt": "2026-05-13T17:32:20.603Z",
+      "lastActivity": "2026-05-13T17:32:20.603Z"
+    },
+    "issue:155": {
+      "type": "issue",
+      "issue": {
+        "number": 155,
+        "title": "Bug: Ctrl+V double-pastes in terminal — custom keydown handler and xterm native paste event both write to PTY"
+      },
+      "status": "shipping",
+      "pipelineStep": "SHIP",
+      "parentRelease": "v0.5.3",
+      "createdAt": "2026-05-13T17:33:18.557Z",
+      "lastActivity": "2026-05-13T17:45:59.071Z",
+      "phase": {
+        "current": 1,
+        "total": 1,
+        "status": "executing"
+      }
+    }
+  },
   "history": {
     "lastCompletedIssue": {
       "number": 154,

--- a/apps/desktop/src/components/terminal/Terminal.tsx
+++ b/apps/desktop/src/components/terminal/Terminal.tsx
@@ -241,7 +241,11 @@ export function Terminal({ className = "", cwd, shell, terminalId, onStatusChang
           terminalFocusRegistry.register(terminalId, () => xterm.focus());
         }
 
-        // Handle copy/paste keyboard shortcuts
+        // Handle copy keyboard shortcut. Paste is intentionally NOT handled
+        // here — xterm.js's built-in paste-event listener owns Ctrl+V and
+        // Ctrl+Shift+V. A custom keydown handler that also calls xterm.paste()
+        // double-pastes, because the browser's separate `paste` DOM event
+        // still fires on xterm's hidden textarea (see #155).
         xterm.attachCustomKeyEventHandler((e: KeyboardEvent) => {
           // Ctrl+Shift+C: Copy selection to clipboard
           if (e.ctrlKey && e.shiftKey && e.key === 'C' && e.type === 'keydown') {
@@ -249,26 +253,6 @@ export function Terminal({ className = "", cwd, shell, terminalId, onStatusChang
             if (selection) {
               navigator.clipboard.writeText(selection);
             }
-            return false; // Prevent xterm from processing
-          }
-
-          // Ctrl+Shift+V: Paste from clipboard
-          if (e.ctrlKey && e.shiftKey && e.key === 'V' && e.type === 'keydown') {
-            navigator.clipboard.readText().then((text) => {
-              if (text) {
-                xterm.paste(text);
-              }
-            });
-            return false; // Prevent xterm from processing
-          }
-
-          // Ctrl+V: Standard paste (supports voice-to-text apps like Wispr)
-          if (e.ctrlKey && !e.shiftKey && e.key === 'v' && e.type === 'keydown') {
-            navigator.clipboard.readText().then((text) => {
-              if (text) {
-                xterm.paste(text);
-              }
-            });
             return false; // Prevent xterm from processing
           }
 


### PR DESCRIPTION
## Summary
- Delete two custom paste branches in `apps/desktop/src/components/terminal/Terminal.tsx` (the Ctrl+Shift+V and Ctrl+V keydown handlers).
- Both called `xterm.paste(clipboardText)` and returned `false` from `attachCustomKeyEventHandler` — but the browser's separate `paste` DOM event still fired on xterm's hidden textarea, causing xterm's built-in paste listener to write the same text a second time.
- xterm.js already handles paste natively via its built-in `paste` event listener. Letting it own paste exclusively fixes the duplication.
- The Ctrl+Shift+C copy branch stays (xterm.js doesn't provide it natively).

## Test plan
- [ ] `pnpm tauri:dev` and verify in a real terminal:
  - [ ] Ctrl+V pastes a 200-char single line once.
  - [ ] Ctrl+V pastes a 5-line block once, line endings preserved.
  - [ ] Ctrl+Shift+V also pastes once.
  - [ ] Ctrl+Shift+C still copies the selection (regression).
- [ ] Wispr / voice-to-text apps still inject text once (they write to the OS clipboard; xterm's native handler reads from there).
- [ ] PowerShell with bracketed-paste enabled wraps the content correctly — only one `\e[200~...\e[201~` pair appears.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)