### PR TITLE
docs(ui): explain Ctrl+Z in terminal is SIGTSTP, not undo (#160)

### DIFF
--- a/.tiki/plans/issue-160.json
+++ b/.tiki/plans/issue-160.json
@@ -1,0 +1,23 @@
+{
+  "issue": {
+    "number": 160,
+    "title": "Enhancement: Add Settings explainer that Ctrl+Z in the terminal is SIGTSTP, not editor undo"
+  },
+  "phases": [
+    {
+      "number": 1,
+      "title": "Add static Ctrl+Z SIGTSTP explainer to Settings → Terminal",
+      "content": "Add a static informational block in `apps/desktop/src/components/settings/SettingsPage.tsx` under the Terminal section, placed after the existing `.settings-hint` paragraph at line 107.\n\nPer the issue body's recommendation (Option B / minimum viable), this is *only* the static Settings copy. Do NOT implement the toast-on-first-press (Option A) — that's an explicit defer in the issue body to avoid pulling in toast infrastructure for a single feature.\n\n**Change to `SettingsPage.tsx`:** insert a new informational block immediately after the existing line `<p className=\"settings-hint\">Terminal settings apply to new terminals only.</p>` (line 107). The new block should be a distinct paragraph styled with a new `.settings-info` class.\n\n```tsx\n          <p className=\"settings-info\">\n            <strong>Ctrl+Z in the terminal</strong> sends <code>SIGTSTP</code> to the running\n            program, suspending it (look for <code>[1]+&nbsp;Stopped</code> in the shell).\n            To resume a suspended job, type <code>fg</code>. This is universal terminal\n            behavior — not editor-style undo. Use the shell's readline editing instead\n            (<code>Ctrl+U</code> clears the line, <code>Ctrl+W</code> deletes a word).\n          </p>\n```\n\n**Change to `SettingsPage.css`:** append a `.settings-info` rule that distinguishes the info block from the lighter `.settings-hint`. Keep it visually congruent with the rest of the Settings styling (uses existing CSS vars). Place after the existing `.settings-hint` rule (line 201-206 area).\n\n```css\n.settings-info {\n  margin: 0;\n  padding: 10px 12px;\n  font-size: 12px;\n  line-height: 1.5;\n  color: var(--text-secondary, #858585);\n  background: rgba(255, 255, 255, 0.03);\n  border-left: 2px solid rgba(255, 255, 255, 0.15);\n  border-radius: 2px;\n}\n\n.settings-info strong {\n  color: var(--text-primary, #cccccc);\n  font-weight: 600;\n}\n\n.settings-info code {\n  font-family: var(--font-mono, 'Cascadia Mono', Consolas, monospace);\n  font-size: 11px;\n  padding: 1px 5px;\n  background: rgba(255, 255, 255, 0.06);\n  border-radius: 3px;\n  color: var(--text-primary, #cccccc);\n}\n```\n\nReasoning for the styling:\n- Subtle background tint + left accent strip differentiates the info block from the italic `.settings-hint` (which is for compact one-liners).\n- Inline `<code>` chips signal keyboard chords and shell command names.\n- Uses `var(--text-secondary)` / `var(--text-primary)` to inherit the project's dark theme tokens. No hard-coded colors except as fallbacks (matches the rest of the file).\n\n**Out of scope for this issue:**\n- The toast-on-first-press (Option A) is explicitly deferred per the issue body.\n- Per-hint dismissal state (`hints.ctrlZDismissed` etc.) is not introduced; no settings-store changes.\n- Mac platform — Cmd+Z behaves consistently (xterm passes it through; no special handling).\n- Localization — not relevant today; no i18n in the project.\n\n**Cross-reference:** the related `Ctrl+W` chord text now reads correctly because issue #156 (already shipped in this release) gated Ctrl+W behind the focus check, so the advice \"use the shell's readline editing — Ctrl+W deletes a word\" is no longer self-contradictory.",
+      "verification": [
+        "SettingsPage.tsx renders a new `.settings-info` paragraph immediately after the existing `.settings-hint` paragraph in the Terminal section.",
+        "The info block mentions: SIGTSTP, `fg` for resuming jobs, that Ctrl+Z is NOT editor undo, and references Ctrl+U / Ctrl+W as readline editing alternatives.",
+        "SettingsPage.css contains a `.settings-info` rule with subtle background, left accent stripe, and styled `<strong>` + `<code>` children.",
+        "No new Settings store fields (hints, dismissal state) are added — this is the minimum-viable static row.",
+        "Local TypeScript verification deferred to CI (`.github/workflows/pr.yml`).",
+        "Manual smoke: Settings page → Terminal section shows the info block under the existing terminal settings, visually distinct from the italic hint above it.",
+        "Manual smoke: copy still reads correctly — no orphaned references or broken sentences."
+      ],
+      "status": "pending"
+    }
+  ]
+}

--- a/.tiki/state.json
+++ b/.tiki/state.json
@@ -15,14 +15,15 @@
         ],
         "completedIssues": [
           156,
-          158
+          158,
+          157
         ],
-        "currentIssue": 157
+        "currentIssue": 160
       },
       "status": "executing",
       "pipelineStep": "EXECUTE",
       "createdAt": "2026-05-13T18:47:01.019Z",
-      "lastActivity": "2026-05-13T19:03:30.621Z"
+      "lastActivity": "2026-05-13T19:07:29.617Z"
     },
     "issue:156": {
       "type": "issue",
@@ -64,10 +65,27 @@
         "number": 157,
         "title": "Bug: PTY reader corrupts multi-byte UTF-8 across 4KB boundaries; also overloads IPC during Tab completion (E4)"
       },
-      "status": "shipping",
+      "status": "completed",
       "pipelineStep": "SHIP",
       "createdAt": "2026-05-13T19:04:43.383Z",
-      "lastActivity": "2026-05-13T19:06:37.623Z",
+      "lastActivity": "2026-05-13T19:07:28.920Z",
+      "parentRelease": "v0.5.4",
+      "phase": {
+        "current": 1,
+        "total": 1,
+        "status": "executing"
+      }
+    },
+    "issue:160": {
+      "type": "issue",
+      "issue": {
+        "number": 160,
+        "title": "Enhancement: Add Settings explainer that Ctrl+Z in the terminal is SIGTSTP, not editor undo"
+      },
+      "status": "shipping",
+      "pipelineStep": "SHIP",
+      "createdAt": "2026-05-13T19:08:37.495Z",
+      "lastActivity": "2026-05-13T19:09:05.966Z",
       "parentRelease": "v0.5.4",
       "phase": {
         "current": 1,
@@ -78,9 +96,9 @@
   },
   "history": {
     "lastCompletedIssue": {
-      "number": 158,
-      "title": "Enhancement: Add 'Clear Scrollback' to terminal tab context menu + Ctrl+Shift+K shortcut (E1)",
-      "completedAt": "2026-05-13T19:03:30.621Z"
+      "number": 157,
+      "title": "Bug: PTY reader corrupts multi-byte UTF-8 across 4KB boundaries; also overloads IPC during Tab completion (E4)",
+      "completedAt": "2026-05-13T19:07:29.617Z"
     },
     "lastCompletedRelease": {
       "version": "v0.5.3",
@@ -91,6 +109,11 @@
       "tag": "v0.5.3"
     },
     "recentIssues": [
+      {
+        "number": 157,
+        "title": "Bug: PTY reader corrupts multi-byte UTF-8 across 4KB boundaries; also overloads IPC during Tab completion (E4)",
+        "completedAt": "2026-05-13T19:07:29.617Z"
+      },
       {
         "number": 158,
         "title": "Enhancement: Add 'Clear Scrollback' to terminal tab context menu + Ctrl+Shift+K shortcut (E1)",

--- a/apps/desktop/src/components/settings/SettingsPage.css
+++ b/apps/desktop/src/components/settings/SettingsPage.css
@@ -204,3 +204,28 @@
   color: var(--text-secondary, #858585);
   font-style: italic;
 }
+
+.settings-info {
+  margin: 0;
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary, #858585);
+  background: rgba(255, 255, 255, 0.03);
+  border-left: 2px solid rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+}
+
+.settings-info strong {
+  color: var(--text-primary, #cccccc);
+  font-weight: 600;
+}
+
+.settings-info code {
+  font-family: var(--font-mono, 'Cascadia Mono', Consolas, monospace);
+  font-size: 11px;
+  padding: 1px 5px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  color: var(--text-primary, #cccccc);
+}

--- a/apps/desktop/src/components/settings/SettingsPage.tsx
+++ b/apps/desktop/src/components/settings/SettingsPage.tsx
@@ -105,6 +105,14 @@ export function SettingsPage() {
             />
           </div>
           <p className="settings-hint">Terminal settings apply to new terminals only.</p>
+
+          <p className="settings-info">
+            <strong>Ctrl+Z in the terminal</strong> sends <code>SIGTSTP</code> to the running
+            program, suspending it (look for <code>[1]+&nbsp;Stopped</code> in the shell).
+            To resume a suspended job, type <code>fg</code>. This is universal terminal
+            behavior — not editor-style undo. Use the shell's readline editing instead
+            (<code>Ctrl+U</code> clears the line, <code>Ctrl+W</code> deletes a word).
+          </p>
         </div>
 
         {/* Appearance */}


### PR DESCRIPTION
Closes #160 — part of v0.5.4 terminal polish.

## Summary

Adds a static informational block to **Settings → Terminal** that explains the universal terminal behavior of Ctrl+Z:

- Sends `SIGTSTP` (suspends the running program), shown by the shell as `[1]+ Stopped`
- Resume with `fg`
- Not editor-style undo — use the shell's readline editing (`Ctrl+U`, `Ctrl+W`) instead

Ships **Option B** (static Settings row) only — the toast-on-first-press (Option A) from the issue body is explicitly deferred.

Visual: new `.settings-info` class with a subtle background, left accent stripe, and styled `<code>` chips. Distinct from the italic `.settings-hint` single-liners.

## Test plan

- [ ] Open Settings → Terminal — info block appears under the existing settings
- [ ] Copy reads cleanly (no orphaned references or broken sentences)
- [ ] `<code>` chips render with the monospace font and subtle background
- [ ] Left accent stripe is visible against the panel background

🤖 Generated with [Claude Code](https://claude.com/claude-code)