### PR TITLE
chore(deps): migrate xterm -> @xterm/xterm 5.5 (#161)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "^12.10.1",
     "dagre": "^0.8.5",
     "framer-motion": "^12.31.0",
@@ -32,7 +33,6 @@
     "react-resizable-panels": "^4.5.8",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "xterm": "^5.3.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/apps/desktop/src/components/terminal/Terminal.tsx
+++ b/apps/desktop/src/components/terminal/Terminal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Terminal as XTerm } from "xterm";
+import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SearchAddon } from "@xterm/addon-search";
@@ -9,8 +9,8 @@ import { useTerminal } from "./useTerminal";
 import { findLeafByTerminalId } from "../../stores/splitTree";
 import { terminalFocusRegistry, terminalActionsRegistry, useTerminalStore } from "../../stores/terminalStore";
 import { useSettingsStore } from "../../stores";
-import type { ITheme } from "xterm";
-import "xterm/css/xterm.css";
+import type { ITheme } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
 import "./Terminal.css";
 
 // --- Terminal theme definitions ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@xterm/addon-web-links':
         specifier: ^0.12.0
         version: 0.12.0
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.1(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -61,9 +64,6 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
-      xterm:
-        specifier: ^5.3.0
-        version: 5.3.0
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.10)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -912,6 +912,9 @@ packages:
 
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   '@xyflow/react@12.10.1':
     resolution: {integrity: sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==}
@@ -1926,10 +1929,6 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  xterm@5.3.0:
-    resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
-    deprecated: This package is now deprecated. Move to @xterm/xterm instead.
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2665,6 +2664,8 @@ snapshots:
   '@xterm/addon-search@0.16.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
+
+  '@xterm/xterm@5.5.0': {}
 
   '@xyflow/react@12.10.1(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3910,8 +3911,6 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
-
-  xterm@5.3.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- Swaps the legacy `xterm@5.3.0` dependency for `@xterm/xterm@5.5.0`. 5.3.0 was the last release on the unscoped name; 5.4+ and 5.5+ ship only under `@xterm/xterm`.
- Updates the three import sites in `apps/desktop/src/components/terminal/Terminal.tsx` (named import, type import, CSS path).
- Lockfile diff is the expected `+1 -1` — addons (`@xterm/addon-fit`, `-web-links`, `-search`) keep their pinned versions; they were already on the scoped namespace.

## Why now

Issue #161 captures the rationale: structural typing was masking the dual-namespace setup, so the substitution worked at runtime but hid `go to definition` and blocked us from picking up bug fixes / accessibility work shipped in `@xterm/xterm` 5.4+.

## Why 5.5 and not 6.0

6.0 is the latest stable on the new namespace but is a major version bump. Keeping the change axis-aligned (namespace migration only) means a future regression is easier to bisect. A 6.0 upgrade should be its own issue with its own smoke test.

## Test plan

- [x] `pnpm install` clean — `+1 -1` (xterm out, @xterm/xterm in)
- [x] `pnpm build` clean (`tsc -b` strict mode + vite production build)
- [x] `pnpm why xterm` from `apps/desktop` reports no users of the legacy package
- [x] `pnpm why @xterm/xterm` reports `@tiki/desktop` as the sole direct dependent
- [ ] `pnpm tauri:dev` smoke test:
  - [ ] Open a terminal tab, type / paste
  - [ ] Ctrl+F search finds matches (addon-search)
  - [ ] Window resize repaints to fit (addon-fit)
  - [ ] Clickable URLs detected (addon-web-links)
  - [ ] No deprecated warnings in DevTools console

This is the v0.5.5 release bundle (single-issue release deferred from v0.5.4 due to the local Windows pnpm-install block, now resolved).

Closes #161

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)