### PR TITLE
fix(terminal): set allowProposedApi to re-enable WebLinksAddon (#169)

### DIFF
--- a/apps/desktop/src/components/terminal/Terminal.tsx
+++ b/apps/desktop/src/components/terminal/Terminal.tsx
@@ -250,6 +250,9 @@ export function Terminal({ className = "", cwd, shell, terminalId, onStatusChang
           lineHeight: 1.2,
           cursorBlink: true,
           cursorStyle: "block",
+          // @xterm/xterm 5.4+ gates some APIs the link/search addons rely on
+          // behind this flag; legacy xterm@5.3 exposed them unconditionally.
+          allowProposedApi: true,
         });
 
         // Add addons


### PR DESCRIPTION
## Summary

Single-line fix: add `allowProposedApi: true` to the `XTerm` constructor in `apps/desktop/src/components/terminal/Terminal.tsx`.

## Hypothesis

xterm.js 5.4's release notes explicitly call out "Remove proposed api checks" and a "Major rework" of `WebLinksAddon`. The legacy `xterm@5.3.0` exposed several internal APIs unconditionally that 5.4+ gates behind the `allowProposedApi: true` constructor flag. `@xterm/addon-web-links@0.12.0` uses one of those proposed APIs internally to register URL click handlers; without the flag, the addon's `loadAddon` succeeds but its proposed-API calls return early, so URL spans never get the click handler attached.

This explains why the v0.5.5 namespace migration (#161) silently broke clickable URLs in the terminal — no error at load time, just dead URLs.

## Test plan

- [x] `pnpm build` clean (`tsc -b` strict + vite production build)
- [ ] `pnpm --filter @tiki/desktop tauri:dev` smoke test: print a URL, attempt to click. Expected: cursor changes on hover, click opens default browser.
- [ ] Confirm Ctrl+F search overlay still works (uses `SearchAddon`, also addon-namespace).
- [ ] Confirm window resize still fits (uses `FitAddon`).

## Scope

This PR addresses the **clickable URLs** symptom from #169 only. Ctrl+V / Ctrl+Shift+C clipboard behavior is intentionally **not** changed — those are independent symptoms whose status (regression vs pre-existing) we'd need a v0.5.4 A/B test to distinguish, and any change to keyboard handling risks re-introducing the #155 double-paste regression. If they're still broken after this PR lands, they'll be a separate follow-up.

## Risk

Low. Adding `allowProposedApi: true` is a documented, stable flag (no version sunset) and only enables APIs that were already exposed in the legacy package. If the hypothesis is wrong, the worst case is "no change in behavior" — not a regression vector.

Refs #169 (partial — clickable URLs symptom; Ctrl+V/C remain open)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
