### PR TITLE
fix(desktop): resolve `claude` CLI beyond PATH (closes #180)

### DIFF
--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -275,31 +275,125 @@ pub fn fetch_github_pr_detail(
 
 // ─── CLI Check Commands ───────────────────────────────────────────────────────
 
-/// Check if Claude CLI is installed and accessible
-/// Returns Ok(true) if installed, Ok(false) if not installed
-#[tauri::command]
-pub fn check_claude_cli() -> Result<bool, String> {
-    // On Windows, we need to run through cmd.exe to find .cmd files in PATH
+/// A resolved, verified way to invoke the Claude CLI on this machine.
+///
+/// Windows GUI apps inherit `explorer.exe`'s *login-time* PATH, so a `claude`
+/// installed (or PATH-registered) after the last login is invisible to the
+/// Tauri process even though a fresh terminal finds it. Probing known install
+/// locations in addition to PATH works around that staleness, and capturing the
+/// concrete invocation here means the availability check and the enhance
+/// command always run the *same* resolved binary.
+#[derive(Clone)]
+struct ClaudeCli {
+    /// Program to spawn — `cmd` when reaching `claude` through PATH or a `.cmd`
+    /// shim on Windows, otherwise the absolute path to the executable.
+    program: String,
+    /// Args that must precede the caller's own (`["/C", "claude"]` for the shim).
+    prefix_args: Vec<String>,
+}
+
+impl ClaudeCli {
+    /// A `Command` pre-loaded with the launcher + prefix args; append your own.
+    fn command(&self) -> Command {
+        let mut cmd = hidden_command(&self.program);
+        cmd.args(&self.prefix_args);
+        cmd
+    }
+}
+
+/// Build a `ClaudeCli` for a concrete file path, picking the right launcher:
+/// `.cmd`/`.bat` shims must go through `cmd /C`, real executables run directly.
+fn claude_at_path(path: String) -> ClaudeCli {
     #[cfg(target_os = "windows")]
-    let output = hidden_command("cmd")
-        .args(["/C", "claude", "--version"])
-        .output();
-
-    #[cfg(not(target_os = "windows"))]
-    let output = hidden_command("claude")
-        .args(["--version"])
-        .output();
-
-    match output {
-        Ok(result) => Ok(result.status.success()),
-        Err(e) => {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                Ok(false)
-            } else {
-                Err(format!("Failed to check Claude CLI: {}", e))
-            }
+    {
+        let lower = path.to_lowercase();
+        if lower.ends_with(".cmd") || lower.ends_with(".bat") {
+            return ClaudeCli {
+                program: "cmd".to_string(),
+                prefix_args: vec!["/C".to_string(), path],
+            };
         }
     }
+    ClaudeCli {
+        program: path,
+        prefix_args: Vec::new(),
+    }
+}
+
+/// Candidate Claude CLI invocations to try, in priority order: whatever is on
+/// PATH first, then known per-user install locations that actually exist on disk.
+fn claude_candidates() -> Vec<ClaudeCli> {
+    let mut candidates = Vec::new();
+
+    // 1. Whatever is on PATH — the happy path for a normally-launched process.
+    #[cfg(target_os = "windows")]
+    candidates.push(ClaudeCli {
+        program: "cmd".to_string(),
+        prefix_args: vec!["/C".to_string(), "claude".to_string()],
+    });
+    #[cfg(not(target_os = "windows"))]
+    candidates.push(ClaudeCli {
+        program: "claude".to_string(),
+        prefix_args: Vec::new(),
+    });
+
+    // 2. Known install locations — covers Windows GUI PATH staleness and
+    //    per-user installs that never made it onto the login PATH.
+    #[cfg(target_os = "windows")]
+    let known: Vec<String> = {
+        let mut v = Vec::new();
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            v.push(format!("{appdata}\\npm\\claude.cmd")); // npm -g
+        }
+        if let Ok(home) = std::env::var("USERPROFILE") {
+            v.push(format!("{home}\\.local\\bin\\claude.exe")); // native installer
+            v.push(format!("{home}\\.claude\\local\\claude.exe")); // legacy local install
+        }
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            v.push(format!("{local}\\Programs\\claude\\claude.exe"));
+        }
+        v
+    };
+    #[cfg(not(target_os = "windows"))]
+    let known: Vec<String> = {
+        let mut v = Vec::new();
+        if let Ok(home) = std::env::var("HOME") {
+            v.push(format!("{home}/.local/bin/claude"));
+            v.push(format!("{home}/.claude/local/claude"));
+            v.push(format!("{home}/.npm-global/bin/claude"));
+        }
+        v.push("/usr/local/bin/claude".to_string());
+        v.push("/opt/homebrew/bin/claude".to_string());
+        v
+    };
+
+    for path in known {
+        if std::path::Path::new(&path).exists() {
+            candidates.push(claude_at_path(path));
+        }
+    }
+
+    candidates
+}
+
+/// Resolve a Claude CLI invocation that actually runs, or `None` if `claude`
+/// can't be found on PATH or in any known install location.
+fn resolve_claude_cli() -> Option<ClaudeCli> {
+    claude_candidates().into_iter().find(|cli| {
+        cli.command()
+            .arg("--version")
+            .output()
+            .map(|out| out.status.success())
+            .unwrap_or(false)
+    })
+}
+
+/// Check if Claude CLI is installed and accessible.
+/// Returns `Ok(true)` if a working `claude` was found (on PATH or in a known
+/// install location), `Ok(false)` otherwise.
+#[tauri::command]
+pub fn check_claude_cli() -> Result<bool, String> {
+    Ok(resolve_claude_cli().is_some())
 }
 
 /// Check if gh CLI is authenticated
@@ -740,37 +834,29 @@ pub fn enhance_issue_description(
         _ => return Err(format!("Unknown enhancement type: {}", enhancement_type)),
     };
 
-    // Use the claude CLI to enhance the description
-    // Pipe the prompt via stdin to avoid shell metacharacter issues
+    // Use the claude CLI to enhance the description.
+    // Resolve it the same way `check_claude_cli` does — PATH plus known install
+    // locations — so the button being enabled always matches what runs here.
+    // Pipe the prompt via stdin to avoid shell metacharacter issues.
+    let cli = resolve_claude_cli().ok_or_else(|| {
+        "Claude CLI not found. Install it from https://github.com/anthropics/claude-code, \
+         then make sure it's on your PATH. (Checked PATH and common install locations \
+         such as the npm global directory and ~/.local/bin.)"
+            .to_string()
+    })?;
 
-    #[cfg(target_os = "windows")]
-    let mut child = hidden_command("cmd")
-        .args(["/C", "claude", "-p"])
+    let mut child = cli
+        .command()
+        .arg("-p")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                "Claude CLI not found. Please install it from https://github.com/anthropics/claude-code and ensure it's in your PATH.".to_string()
-            } else {
-                format!("Failed to run Claude CLI: {}. Make sure Claude CLI is properly installed and configured.", e)
-            }
-        })?;
-
-    #[cfg(not(target_os = "windows"))]
-    let mut child = hidden_command("claude")
-        .args(["-p"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                "Claude CLI not found. Please install it from https://github.com/anthropics/claude-code and ensure it's in your PATH.".to_string()
-            } else {
-                format!("Failed to run Claude CLI: {}. Make sure Claude CLI is properly installed and configured.", e)
-            }
+            format!(
+                "Failed to run Claude CLI ({}): {}. Make sure Claude CLI is properly installed and configured.",
+                cli.program, e
+            )
         })?;
 
     // Write prompt to stdin and close it

--- a/apps/desktop/src/components/ui/IssueFormModal.tsx
+++ b/apps/desktop/src/components/ui/IssueFormModal.tsx
@@ -350,7 +350,7 @@ export function IssueFormModal({
                   disabled={loading || enhancing || !body.trim() || claudeCliAvailable === false}
                   aria-expanded={enhanceDropdownOpen}
                   aria-haspopup="menu"
-                  title={claudeCliAvailable === false ? "Claude CLI not installed. Install from https://github.com/anthropics/claude-code" : undefined}
+                  title={claudeCliAvailable === false ? "Claude CLI not found on PATH or in common install locations. Install it from https://github.com/anthropics/claude-code, or ensure it's on your PATH." : undefined}
                 >
                   {enhancing ? (
                     <>
@@ -374,7 +374,7 @@ export function IssueFormModal({
                           strokeLinejoin="round"
                         />
                       </svg>
-                      CLI not installed
+                      CLI not found
                     </>
                   ) : (
                     <>


### PR DESCRIPTION
## Summary

Fixes #180 — the "Enhance using AI" button in the Create Issue modal mislabeled "CLI not installed" even when Claude Code was installed, because Windows GUI processes inherit `explorer.exe`'s *login-time* PATH and a `claude` registered after the last login is invisible to them.

## What changed

`apps/desktop/src-tauri/src/github.rs`:
- New `ClaudeCli` struct + `resolve_claude_cli()` helper that tries PATH first, then probes known per-user install locations on disk:
  - **Windows**: `%APPDATA%\npm\claude.cmd`, `%USERPROFILE%\.local\bin\claude.exe`, `%USERPROFILE%\.claude\local\claude.exe`, `%LOCALAPPDATA%\Programs\claude\claude.exe`
  - **Unix**: `~/.local/bin/claude`, `~/.claude/local/claude`, `~/.npm-global/bin/claude`, `/usr/local/bin/claude`, `/opt/homebrew/bin/claude`
- `check_claude_cli` and `enhance_issue_description` now **share** the resolver, so the button-enabled state always matches what actually runs.
- `.cmd`/`.bat` shims go through `cmd /C` (avoids Rust's `Command` quirks spawning batch files directly); `.exe` paths run directly.

`apps/desktop/src/components/ui/IssueFormModal.tsx`:
- Button label softened "CLI not installed" → **"CLI not found"** (accurate for either failure mode).
- Tooltip now says it checked PATH *and* common install locations, with the install URL.

## Test plan

- [x] `cargo check` passes
- [x] `pnpm build` passes
- [x] Manual smoke test on the reporter's machine (npm-global install at `%APPDATA%\Roaming\npm\claude.cmd`): button correctly enables, Enhance-with-AI runs successfully
- [ ] CI green
- [ ] Reviewer smoke-tests on a second machine

## Notes / related

This is the narrow case of the broader **E63 — Environment Doctor** idea (filed in #178); E63's Settings panel will eventually let users see resolved paths + override them, but this fix unblocks the immediate user-visible bug now.

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
