### PR TITLE
fix: release-shipped issues now reach Kanban Completed (#219)

### DIFF
--- a/.claude/commands/tiki/release.md
+++ b/.claude/commands/tiki/release.md
@@ -182,7 +182,13 @@ After shipping:
 ```bash
 # Remove the release entry from activeWork:
 node packages/framework/scripts/state.mjs remove release:{version}
-# For each child issue with parentRelease == {version}, remove it:
+# For EACH child issue with parentRelease == {version} (run the next two lines
+# once per child): append it to history.recentIssues FIRST (so the desktop
+# Kanban "Completed" column, which reads recentIssues, shows release-shipped
+# issues — mirrors ship.md), THEN remove it from activeWork. append-history is
+# idempotent on issue number, so this is safe even if ship.md already appended
+# the child during the cascade.
+node packages/framework/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
 node packages/framework/scripts/state.mjs remove issue:{number}
 # Append the release completion record to history:
 node packages/framework/scripts/state.mjs append-history release --version {version} --issues "41,42,43" --tag {version}

--- a/.tiki/plans/archive/issue-219.json
+++ b/.tiki/plans/archive/issue-219.json
@@ -1,0 +1,138 @@
+{
+  "schemaVersion": 1,
+  "issue": {
+    "number": 219,
+    "title": "A: Release-shipped issues never reach Kanban Completed (live data-loss)",
+    "url": "https://github.com/Eric-Ness/Tiki-V2/issues/219",
+    "labels": [
+      "bug",
+      "desktop",
+      "framework",
+      "reliability"
+    ],
+    "milestone": "epic #218"
+  },
+  "createdAt": "2026-05-21T02:30:00.000Z",
+  "successCriteria": [
+    {
+      "id": "SC1",
+      "category": "functional",
+      "description": "release.md teardown appends issue history per child (all 3 shadows), and append-history is idempotent (dedupes by number/version)",
+      "verified": true,
+      "verifiedAt": "2026-05-21T12:01:45.190Z"
+    },
+    {
+      "id": "SC2",
+      "category": "functional",
+      "description": "Kanban Completed column unions recentIssues + recentReleases[].issues deduped by number; cross-column exclusion set is uncapped; render cap raised (~50)",
+      "verified": true,
+      "verifiedAt": "2026-05-21T12:01:45.190Z"
+    },
+    {
+      "id": "SC3",
+      "category": "functional",
+      "description": "Already-shipped release children (v0.6.6 #214/#215/#216) appear in Completed exactly once with no state.json migration",
+      "verified": true,
+      "verifiedAt": "2026-05-21T12:01:45.190Z"
+    },
+    {
+      "id": "SC4",
+      "category": "testing",
+      "description": "Pure-function tests for the union/dedup + a command-transition-coverage assertion that release.md teardown appends issue history per child",
+      "verified": true,
+      "verifiedAt": "2026-05-21T12:01:45.190Z"
+    },
+    {
+      "id": "SC5",
+      "category": "other",
+      "description": "pnpm build + shared/desktop vitest + framework node:test green",
+      "verified": true,
+      "verifiedAt": "2026-05-21T12:01:45.190Z"
+    }
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "title": "Framework: idempotent append-history + per-child append in release.md",
+      "status": "completed",
+      "content": "Make state.mjs handleAppendHistory idempotent (dedupe by number for issues / version for releases before unshift). Add per-child `append-history issue --number {number} --title \"{title}\"` to release.md teardown in all 3 shadows. Add a command-transition-coverage assertion that release.md teardown appends issue history per child.",
+      "verification": [
+        "framework node:test passes incl. new assertion",
+        "append-history re-run does not duplicate",
+        "all 3 release.md shadows updated"
+      ],
+      "addressesCriteria": [
+        "SC1",
+        "SC4"
+      ],
+      "files": [
+        "packages/framework/scripts/state.mjs",
+        "packages/framework/commands/release.md",
+        "packages/framework/.claude/commands/tiki/release.md",
+        ".claude/commands/tiki/release.md",
+        "packages/framework/__tests__/command-transition-coverage.test.mjs"
+      ],
+      "completedAt": "2026-05-21T12:01:45.190Z",
+      "summary": "state.mjs append-history now idempotent (dedupe by number/version before unshift); all 3 release.md shadows append issue history per child before remove; command-transition-coverage asserts release.md teardown appends issue history."
+    },
+    {
+      "number": 2,
+      "title": "Frontend: Completed column unions recentReleases, deduped + uncapped exclusion",
+      "status": "completed",
+      "content": "Expose recentReleases in tikiStateStore + sync in App.tsx (stable EMPTY const). KanbanBoard: union recentIssues + recentReleases[].issues for both the completed render (deduped, render cap ~50) and the exclusion set (uncapped). Extract pure helpers + unit-test against a v0.6.6-shaped fixture.",
+      "verification": [
+        "v0.6.6 children render once in Completed",
+        "no issue in two columns",
+        "pure-function tests pass"
+      ],
+      "addressesCriteria": [
+        "SC2",
+        "SC3",
+        "SC4"
+      ],
+      "files": [
+        "apps/desktop/src/stores/tikiStateStore.ts",
+        "apps/desktop/src/App.tsx",
+        "apps/desktop/src/components/kanban/KanbanBoard.tsx"
+      ],
+      "completedAt": "2026-05-21T12:01:45.190Z",
+      "summary": "tikiStateStore exposes recentReleases (+App.tsx sync via stable EMPTY_RECENT_RELEASES const); new pure completedColumn.ts (collectCompletedIssueNumbers uncapped union + buildCompletedCards deduped, cap 50); KanbanBoard consumes both. 7 fixture tests incl. v0.6.6 exactly-once."
+    },
+    {
+      "number": 3,
+      "title": "Verify",
+      "status": "completed",
+      "content": "pnpm build + vitest (shared/desktop) + framework node:test. Fix failures.",
+      "verification": [
+        "pnpm build green",
+        "all test suites green"
+      ],
+      "addressesCriteria": [
+        "SC5"
+      ],
+      "files": [],
+      "completedAt": "2026-05-21T12:01:45.190Z",
+      "summary": "pnpm build clean; shared 86, desktop 151 (+29), framework 22 (+new assertion). No Rust."
+    }
+  ],
+  "coverageMatrix": {
+    "SC1": [
+      1
+    ],
+    "SC2": [
+      2
+    ],
+    "SC3": [
+      2
+    ],
+    "SC4": [
+      1,
+      2
+    ],
+    "SC5": [
+      3
+    ]
+  },
+  "notes": "Wave 1 / MVP of epic #218. Frontend union (deduped) repairs already-shipped releases with no migration; framework fix makes future releases populate recentIssues natively. Ship standalone (not via /tiki:release) to avoid the dogfooding trap.",
+  "updatedAt": "2026-05-21T12:01:45.190Z"
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -25,7 +25,7 @@ import { CommandPalette, ErrorBoundary, KeyboardShortcuts } from "./components/u
 import { useCommandActions, useStaleWorkDetection } from "./hooks";
 import { StateRecoveryDialog } from "./components/recovery";
 import type { WorkContext } from "./components/work";
-import { useLayoutStore, useDetailStore, useIssuesStore, useReleasesStore, useProjectsStore, useTikiReleasesStore, useTikiStateStore, useTerminalStore, useToastStore, usePullRequestsStore, useCommandPaletteStore, useResearchStore, useSettingsStore, useBulkYoloStore } from "./stores";
+import { useLayoutStore, useDetailStore, useIssuesStore, useReleasesStore, useProjectsStore, useTikiReleasesStore, useTikiStateStore, useTerminalStore, useToastStore, usePullRequestsStore, useCommandPaletteStore, useResearchStore, useSettingsStore, useBulkYoloStore, type CompletedRelease } from "./stores";
 import type { GitHubIssue, ResearchDocMeta, TikiRelease } from "./stores";
 import { terminalFocusRegistry } from "./stores/terminalStore";
 import { detectGithubRefreshTriggers } from "./utils/githubRefreshTriggers";
@@ -59,6 +59,23 @@ function scheduleRefresh(surface: RefreshSurface, fire: () => void): void {
 // via useEffect dep instability (same bug class as #210 — see #212).
 const EMPTY_ACTIVE_WORK: Record<string, WorkContext> = {};
 const EMPTY_RECENT_ISSUES: Array<{ number: number; title?: string; completedAt: string }> = [];
+const EMPTY_RECENT_RELEASES: CompletedRelease[] = [];
+
+// Normalize raw history.recentReleases (where `issues` may be absent) into the
+// store's CompletedRelease shape (`issues: number[]`). Returns the stable
+// EMPTY_RECENT_RELEASES const when there is nothing, so consumers never see a
+// fresh empty-array ref (same fresh-ref bug class as #210/#212).
+function normalizeRecentReleases(
+  raw: Array<{ version: string; issues?: number[]; completedAt: string; tag?: string }> | undefined,
+): CompletedRelease[] {
+  if (!raw || raw.length === 0) return EMPTY_RECENT_RELEASES;
+  return raw.map((r) => ({
+    version: r.version,
+    issues: r.issues ?? [],
+    completedAt: r.completedAt,
+    ...(r.tag !== undefined ? { tag: r.tag } : {}),
+  }));
+}
 
 // Types matching Rust state structures
 interface TikiState {
@@ -248,8 +265,9 @@ function App() {
         if (currentState?.activeWork) {
           useTikiStateStore.getState().setActiveWork(currentState.activeWork);
         }
-        // Sync recentIssues for Completed column
+        // Sync recentIssues + recentReleases for Completed column
         useTikiStateStore.getState().setRecentIssues(currentState?.history?.recentIssues ?? EMPTY_RECENT_ISSUES);
+        useTikiStateStore.getState().setRecentReleases(normalizeRecentReleases(currentState?.history?.recentReleases));
       } catch (e) {
         console.error("Error loading state:", e);
         setError(String(e));
@@ -275,8 +293,9 @@ function App() {
       if (currentState?.activeWork) {
         useTikiStateStore.getState().setActiveWork(currentState.activeWork);
       }
-      // Sync recentIssues for Completed column
+      // Sync recentIssues + recentReleases for Completed column
       useTikiStateStore.getState().setRecentIssues(currentState?.history?.recentIssues ?? EMPTY_RECENT_ISSUES);
+      useTikiStateStore.getState().setRecentReleases(normalizeRecentReleases(currentState?.history?.recentReleases));
     } catch (e) {
       console.error("Error loading state:", e);
       setError(String(e));
@@ -359,8 +378,9 @@ function App() {
             console.log("Syncing to tikiStateStore:", Object.entries(currentState.activeWork).map(([k, v]) => `${k}: ${v.status}`));
             useTikiStateStore.getState().setActiveWork(currentState.activeWork);
           }
-          // Sync recentIssues for Completed column
+          // Sync recentIssues + recentReleases for Completed column
           useTikiStateStore.getState().setRecentIssues(currentState?.history?.recentIssues ?? EMPTY_RECENT_ISSUES);
+          useTikiStateStore.getState().setRecentReleases(normalizeRecentReleases(currentState?.history?.recentReleases));
         } catch (e) {
           console.error("Failed to reload state:", e);
         }

--- a/apps/desktop/src/components/kanban/KanbanBoard.tsx
+++ b/apps/desktop/src/components/kanban/KanbanBoard.tsx
@@ -19,6 +19,7 @@ import { KanbanColumn } from './KanbanColumn';
 import { KanbanCard, type WorkItem } from './KanbanCard';
 import { KanbanFilters } from './KanbanFilters';
 import { getExecuteCommand } from './executeCommand';
+import { collectCompletedIssueNumbers, buildCompletedCards } from './completedColumn';
 import './kanban.css';
 
 // Valid state transitions for drag-and-drop
@@ -60,6 +61,7 @@ export function KanbanBoard() {
   const setActiveView = useLayoutStore((s) => s.setActiveView);
   const activeWork = useTikiStateStore((s) => s.activeWork);
   const recentIssues = useTikiStateStore((s) => s.recentIssues);
+  const recentReleases = useTikiStateStore((s) => s.recentReleases);
   const [activeId, setActiveId] = useState<number | null>(null);
   const [shipConfirmation, setShipConfirmation] = useState<{ issueNumber: number; title: string } | null>(null);
 
@@ -307,32 +309,29 @@ export function KanbanBoard() {
     return map;
   }, [activeWork]);
 
-  // Get set of completed issue numbers from history (for exclusion from other columns)
+  // Get set of completed issue numbers from history (for exclusion from other
+  // columns). Uncapped union of recentIssues + every recentReleases[].issues[]
+  // so release-shipped children are excluded from non-completed columns too
+  // (issue #219).
   const completedIssueNumbers = useMemo(() => {
-    return new Set(recentIssues.slice(0, 8).map((i) => i.number));
-  }, [recentIssues]);
+    return collectCompletedIssueNumbers(recentIssues, recentReleases);
+  }, [recentIssues, recentReleases]);
+
+  // Synthesized cards for the Completed column: union of recentIssues +
+  // release children, deduped (recentIssues win), sorted desc, capped at 50.
+  const completedCards = useMemo(() => {
+    return buildCompletedCards(recentIssues, recentReleases, 50);
+  }, [recentIssues, recentReleases]);
 
   // Organize issues into columns based on Tiki work status
   const columns: ColumnData[] = useMemo(() => {
     const result = COLUMN_CONFIG.map((col) => {
-      // For the completed column, use recentIssues from history (limited to 8)
+      // For the completed column, use the union of recentIssues + release
+      // children from history (capped at 50, deduped — issue #219).
       if (col.id === 'completed') {
-        const completedIssues: GitHubIssue[] = [...recentIssues]
-          .sort((a, b) => new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime())
-          .slice(0, 8)
-          .map((recent) => ({
-          number: recent.number,
-          title: recent.title || `Issue #${recent.number}`,
-          state: 'CLOSED',
-          body: '',
-          labels: [],
-          url: `#${recent.number}`,
-          createdAt: recent.completedAt,
-          updatedAt: recent.completedAt,
-        }));
         return {
           ...col,
-          issues: applyColumnOrder(filterIssuesBySearch(completedIssues, searchQuery), orderByColumn[col.id]),
+          issues: applyColumnOrder(filterIssuesBySearch(completedCards, searchQuery), orderByColumn[col.id]),
         };
       }
 
@@ -362,7 +361,7 @@ export function KanbanBoard() {
       return { ...col, issues: applyColumnOrder(colIssues, orderByColumn[col.id]) };
     });
     return result;
-  }, [filteredIssues, activeWork, recentIssues, completedIssueNumbers, searchQuery, orderByColumn]);
+  }, [filteredIssues, activeWork, completedCards, completedIssueNumbers, searchQuery, orderByColumn]);
 
   return (
     <DndContext

--- a/apps/desktop/src/components/kanban/__tests__/completedColumn.test.ts
+++ b/apps/desktop/src/components/kanban/__tests__/completedColumn.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectCompletedIssueNumbers,
+  buildCompletedCards,
+} from '../completedColumn';
+import type { CompletedIssue, CompletedRelease } from '../../../stores';
+
+describe('completedColumn helpers (issue #219)', () => {
+  describe('v0.6.6 shape: release children missing from recentIssues', () => {
+    // Mirrors the live bug: recentIssues has 212/211 but NOT 214/215/216;
+    // those three live only in recentReleases[0].issues = [216, 214, 215].
+    const recentIssues: CompletedIssue[] = [
+      { number: 212, title: 'Fix blank screen v2', completedAt: '2026-05-19T00:00:00Z' },
+      { number: 211, title: 'Kanban pipeline fix', completedAt: '2026-05-19T01:00:00Z' },
+    ];
+    const recentReleases: CompletedRelease[] = [
+      {
+        version: 'v0.6.6',
+        issues: [216, 214, 215],
+        completedAt: '2026-05-20T00:00:00Z',
+        tag: 'v0.6.6',
+      },
+    ];
+
+    it('collectCompletedIssueNumbers unions recentIssues + release children', () => {
+      const set = collectCompletedIssueNumbers(recentIssues, recentReleases);
+      expect(set.has(212)).toBe(true);
+      expect(set.has(211)).toBe(true);
+      expect(set.has(214)).toBe(true);
+      expect(set.has(215)).toBe(true);
+      expect(set.has(216)).toBe(true);
+      expect(set.size).toBe(5);
+    });
+
+    it('buildCompletedcards renders 214/215/216 exactly once each (no dupes)', () => {
+      const cards = buildCompletedCards(recentIssues, recentReleases);
+      const count = (n: number) => cards.filter((c) => c.number === n).length;
+      expect(count(214)).toBe(1);
+      expect(count(215)).toBe(1);
+      expect(count(216)).toBe(1);
+      // and the synthesized release children use the placeholder title
+      const c214 = cards.find((c) => c.number === 214);
+      expect(c214?.title).toBe('Issue #214');
+      expect(c214?.state).toBe('CLOSED');
+      // all five completed items present, none duplicated
+      expect(cards).toHaveLength(5);
+      const numbers = cards.map((c) => c.number).sort((a, b) => a - b);
+      expect(numbers).toEqual([211, 212, 214, 215, 216]);
+    });
+  });
+
+  describe('overlap: number in BOTH recentIssues and a release', () => {
+    const recentIssues: CompletedIssue[] = [
+      { number: 300, title: 'Real title from recentIssues', completedAt: '2026-05-20T00:00:00Z' },
+    ];
+    const recentReleases: CompletedRelease[] = [
+      { version: 'v9.9', issues: [300, 301], completedAt: '2026-05-20T00:00:00Z' },
+    ];
+
+    it('appears once, with the recentIssues title (not the placeholder)', () => {
+      const cards = buildCompletedCards(recentIssues, recentReleases);
+      const matches = cards.filter((c) => c.number === 300);
+      expect(matches).toHaveLength(1);
+      expect(matches[0].title).toBe('Real title from recentIssues');
+      // the release-only child (301) is still synthesized
+      expect(cards.find((c) => c.number === 301)?.title).toBe('Issue #301');
+      expect(cards).toHaveLength(2);
+    });
+
+    it('exclusion set counts the overlapping number once', () => {
+      const set = collectCompletedIssueNumbers(recentIssues, recentReleases);
+      expect(set.has(300)).toBe(true);
+      expect(set.has(301)).toBe(true);
+      expect(set.size).toBe(2);
+    });
+  });
+
+  describe('uncapped exclusion set (>8 completed numbers)', () => {
+    const recentIssues: CompletedIssue[] = Array.from({ length: 6 }, (_, i) => ({
+      number: 100 + i,
+      title: `Issue ${100 + i}`,
+      completedAt: '2026-05-20T00:00:00Z',
+    }));
+    const recentReleases: CompletedRelease[] = [
+      { version: 'vBig', issues: [200, 201, 202, 203, 204], completedAt: '2026-05-20T00:00:00Z' },
+    ];
+
+    it('includes ALL completed numbers, not just the first 8', () => {
+      const set = collectCompletedIssueNumbers(recentIssues, recentReleases);
+      expect(set.size).toBe(11);
+      for (let i = 0; i < 6; i++) expect(set.has(100 + i)).toBe(true);
+      for (const n of [200, 201, 202, 203, 204]) expect(set.has(n)).toBe(true);
+    });
+  });
+
+  describe('cap and sort', () => {
+    it('caps buildCompletedCards at the given cap, newest first', () => {
+      const recentIssues: CompletedIssue[] = Array.from({ length: 60 }, (_, i) => ({
+        number: i + 1,
+        title: `Issue ${i + 1}`,
+        // higher index = more recent
+        completedAt: new Date(2026, 0, 1, 0, i).toISOString(),
+      }));
+      const cards = buildCompletedCards(recentIssues, [], 50);
+      expect(cards).toHaveLength(50);
+      // newest (highest minute = number 60) comes first
+      expect(cards[0].number).toBe(60);
+      // sorted strictly descending by completedAt
+      for (let i = 1; i < cards.length; i++) {
+        expect(new Date(cards[i - 1].updatedAt).getTime()).toBeGreaterThanOrEqual(
+          new Date(cards[i].updatedAt).getTime(),
+        );
+      }
+    });
+  });
+
+  describe('empty inputs', () => {
+    it('returns an empty set and empty cards', () => {
+      expect(collectCompletedIssueNumbers([], []).size).toBe(0);
+      expect(buildCompletedCards([], [])).toEqual([]);
+    });
+  });
+});

--- a/apps/desktop/src/components/kanban/completedColumn.ts
+++ b/apps/desktop/src/components/kanban/completedColumn.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure helpers for building the Kanban "Completed" column (issue #219).
+ *
+ * Background: `/tiki:release` removes child issues from `activeWork` but
+ * historically only recorded the release in `history.recentReleases` — never
+ * appending the individual issues to `history.recentIssues`. The Completed
+ * column read ONLY `recentIssues`, so release-shipped issues vanished from the
+ * board. These helpers union both sources so release children stay visible
+ * even when the per-issue history append is missing (older state files) or when
+ * a release lists issues that never had a standalone recentIssues entry.
+ *
+ * Kept as standalone pure functions (env:'node' testable, like
+ * utils/githubRefreshTriggers.ts) so they can be unit-tested without React.
+ */
+
+import type { GitHubIssue } from '../../stores';
+import type { CompletedIssue, CompletedRelease } from '../../stores';
+
+/**
+ * Union of every completed issue number, drawn from BOTH
+ * `recentIssues[].number` and every `recentReleases[].issues[]`. Uncapped —
+ * this is the exclusion set that keeps already-completed issues out of the
+ * other columns, so it must be exhaustive regardless of how many there are.
+ */
+export function collectCompletedIssueNumbers(
+  recentIssues: CompletedIssue[],
+  recentReleases: CompletedRelease[],
+): Set<number> {
+  const set = new Set<number>();
+  for (const issue of recentIssues) {
+    if (issue && Number.isFinite(issue.number)) {
+      set.add(issue.number);
+    }
+  }
+  for (const release of recentReleases) {
+    if (!release || !Array.isArray(release.issues)) continue;
+    for (const num of release.issues) {
+      if (Number.isFinite(num)) {
+        set.add(num);
+      }
+    }
+  }
+  return set;
+}
+
+/**
+ * Build the synthesized GitHubIssue cards for the Completed column.
+ *
+ * Sources, in precedence order:
+ *  1. `recentIssues` — these carry a real title + completedAt, so they win.
+ *  2. `recentReleases[].issues[]` — number-only entries; synthesized into a
+ *     placeholder card ONLY when the number isn't already present from (1).
+ *     This means a future release whose children DO appear in recentIssues
+ *     (with real titles) take precedence over the number-only release entry.
+ *
+ * Deduped by issue number, sorted by completedAt descending, then capped.
+ */
+export function buildCompletedCards(
+  recentIssues: CompletedIssue[],
+  recentReleases: CompletedRelease[],
+  cap = 50,
+): GitHubIssue[] {
+  const byNumber = new Map<number, GitHubIssue>();
+
+  // (1) recentIssues first — they own the number and the real title.
+  for (const recent of recentIssues) {
+    if (!recent || !Number.isFinite(recent.number)) continue;
+    if (byNumber.has(recent.number)) continue;
+    byNumber.set(recent.number, {
+      number: recent.number,
+      title: recent.title || `Issue #${recent.number}`,
+      state: 'CLOSED',
+      body: '',
+      labels: [],
+      url: `#${recent.number}`,
+      createdAt: recent.completedAt,
+      updatedAt: recent.completedAt,
+    });
+  }
+
+  // (2) release children that aren't already covered by recentIssues.
+  for (const release of recentReleases) {
+    if (!release || !Array.isArray(release.issues)) continue;
+    for (const num of release.issues) {
+      if (!Number.isFinite(num) || byNumber.has(num)) continue;
+      byNumber.set(num, {
+        number: num,
+        title: `Issue #${num}`,
+        state: 'CLOSED',
+        body: '',
+        labels: [],
+        url: `#${num}`,
+        createdAt: release.completedAt,
+        updatedAt: release.completedAt,
+      });
+    }
+  }
+
+  return [...byNumber.values()]
+    .sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    )
+    .slice(0, cap);
+}

--- a/apps/desktop/src/stores/index.ts
+++ b/apps/desktop/src/stores/index.ts
@@ -70,7 +70,11 @@ export {
   type BulkYoloRun,
 } from './bulkYoloStore';
 
-export { useTikiStateStore } from './tikiStateStore';
+export {
+  useTikiStateStore,
+  type CompletedIssue,
+  type CompletedRelease,
+} from './tikiStateStore';
 
 export {
   useToastStore,

--- a/apps/desktop/src/stores/tikiStateStore.ts
+++ b/apps/desktop/src/stores/tikiStateStore.ts
@@ -7,14 +7,23 @@ export interface CompletedIssue {
   completedAt: string;
 }
 
+export interface CompletedRelease {
+  version: string;
+  issues: number[];
+  completedAt: string;
+  tag?: string;
+}
+
 interface TikiStateState {
   activeWork: Record<string, WorkContext>;
   recentIssues: CompletedIssue[];
+  recentReleases: CompletedRelease[];
 }
 
 interface TikiStateActions {
   setActiveWork: (activeWork: Record<string, WorkContext>) => void;
   setRecentIssues: (recentIssues: CompletedIssue[]) => void;
+  setRecentReleases: (recentReleases: CompletedRelease[]) => void;
   getIssueWorkStatus: (issueNumber: number) => string | null;
 }
 
@@ -23,6 +32,7 @@ type TikiStateStore = TikiStateState & TikiStateActions;
 const initialState: TikiStateState = {
   activeWork: {},
   recentIssues: [],
+  recentReleases: [],
 };
 
 export const useTikiStateStore = create<TikiStateStore>()((set, get) => ({
@@ -31,6 +41,8 @@ export const useTikiStateStore = create<TikiStateStore>()((set, get) => ({
   setActiveWork: (activeWork) => set({ activeWork }),
 
   setRecentIssues: (recentIssues) => set({ recentIssues }),
+
+  setRecentReleases: (recentReleases) => set({ recentReleases }),
 
   // Get the work status for a specific issue
   getIssueWorkStatus: (issueNumber) => {

--- a/packages/framework/.claude/commands/tiki/release.md
+++ b/packages/framework/.claude/commands/tiki/release.md
@@ -236,7 +236,7 @@ When starting a release, create the work entry in `.tiki/state.json`:
 
 **After shipping completes**:
 1. Remove `release:{version}` from `activeWork`
-2. Remove ALL child `issue:N` entries from `activeWork` where `parentRelease` matches this release version
+2. For EACH child issue with `parentRelease == {version}` (once per child): first run `node packages/framework/scripts/state.mjs append-history issue --number {number} --title "{issue title}"` so it lands in `history.recentIssues` (the desktop Kanban "Completed" column reads `recentIssues` — mirrors `ship.md`), THEN remove the `issue:N` entry from `activeWork`. `append-history` is idempotent on issue number, so this is safe even if `ship.md` already appended the child during the cascade.
 3. Add to `history.recentReleases`
 4. Archive release file to `.tiki/releases/archive/`
 </state-management>

--- a/packages/framework/__tests__/command-transition-coverage.test.mjs
+++ b/packages/framework/__tests__/command-transition-coverage.test.mjs
@@ -95,3 +95,24 @@ test("every command file retains its expected state.mjs transition --to-step pai
     `pairing so the desktop kanban board reflects pipeline progress (issue #211).`
   );
 });
+
+// Regression assertion for issue #219: the release teardown must append each
+// child issue to history.recentIssues (`append-history issue`). Without it, the
+// desktop Kanban "Completed" column — which reads only recentIssues — drops
+// release-shipped issues even though they were closed. This guards against the
+// step silently disappearing from release.md again.
+test("release.md teardown appends child issues to history (append-history issue)", () => {
+  const filePath = path.join(COMMANDS_DIR, "release.md");
+  assert.ok(
+    fs.existsSync(filePath),
+    `release.md not found at ${filePath}`
+  );
+  const content = fs.readFileSync(filePath, "utf-8");
+  assert.match(
+    content,
+    /state\.mjs\s+append-history\s+issue/,
+    `release.md must invoke 'state.mjs append-history issue' in its teardown so ` +
+    `release-shipped child issues land in history.recentIssues and stay visible ` +
+    `in the desktop Kanban Completed column (issue #219).`
+  );
+});

--- a/packages/framework/commands/release.md
+++ b/packages/framework/commands/release.md
@@ -280,7 +280,13 @@ After shipping:
 ```bash
 # Remove the release entry from activeWork:
 node packages/framework/scripts/state.mjs remove release:{version}
-# For each child issue with parentRelease == {version}, remove it:
+# For EACH child issue with parentRelease == {version} (run the next two lines
+# once per child): append it to history.recentIssues FIRST (so the desktop
+# Kanban "Completed" column, which reads recentIssues, shows release-shipped
+# issues — mirrors ship.md), THEN remove it from activeWork. append-history is
+# idempotent on issue number, so this is safe even if ship.md already appended
+# the child during the cascade.
+node packages/framework/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
 node packages/framework/scripts/state.mjs remove issue:{number}
 # Append the release completion record to history:
 node packages/framework/scripts/state.mjs append-history release --version {version} --issues "41,42,43" --tag {version}

--- a/packages/framework/scripts/state.mjs
+++ b/packages/framework/scripts/state.mjs
@@ -644,6 +644,12 @@ function handleAppendHistory(args) {
     state.history.recentIssues = Array.isArray(state.history.recentIssues)
       ? state.history.recentIssues
       : [];
+    // Idempotent: drop any prior entry for the same issue number before
+    // re-inserting, so re-running append-history (e.g. ship.md during the
+    // cascade AND release.md teardown) never duplicates a child issue.
+    state.history.recentIssues = state.history.recentIssues.filter(
+      (entry) => entry == null || entry.number !== record.number
+    );
     state.history.recentIssues.unshift(record);
     state.history.lastCompletedIssue = record;
   } else {
@@ -651,6 +657,11 @@ function handleAppendHistory(args) {
     state.history.recentReleases = Array.isArray(state.history.recentReleases)
       ? state.history.recentReleases
       : [];
+    // Idempotent: drop any prior entry for the same release version before
+    // re-inserting, so re-running append-history release never duplicates.
+    state.history.recentReleases = state.history.recentReleases.filter(
+      (entry) => entry == null || entry.version !== record.version
+    );
     state.history.recentReleases.unshift(record);
     state.history.lastCompletedRelease = record;
   }


### PR DESCRIPTION
Closes #219. Wave 1 / MVP of epic #218 — the live data-loss bug.

`/tiki:release` removed child issues from `activeWork` but never added them to `history.recentIssues`; the Kanban Completed column read only `recentIssues` → release-shipped issues vanished from the board. Verified live: v0.6.6's #214/#215/#216 were missing from `recentIssues`.

## Changes
- **`state.mjs`**: `append-history` is now idempotent (dedupe by issue number / release version before unshift).
- **`release.md` (all 3 shadows)**: teardown appends issue history per child before removing it (mirrors `ship.md`); `command-transition-coverage` asserts it so the gap can't return.
- **desktop**: `tikiStateStore` exposes `recentReleases` (synced via a stable `EMPTY_RECENT_RELEASES` const — no fresh-ref, guards #210/#212); new pure `completedColumn` helpers union `recentIssues` + `recentReleases[].issues` deduped for the Completed render (cap 50) and the cross-column exclusion set (uncapped). **Retroactively surfaces already-shipped release children (v0.6.6) with no state.json migration.**

## Verification
`pnpm build` clean; shared 86, desktop 151 (+7 `completedColumn` fixtures incl. a v0.6.6 exactly-once test), framework 22 (+ release-teardown assertion). No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
