### PR TITLE
Write integrity — state.mjs lock + watcher active-project repoint (#224)

### DIFF
--- a/.tiki/plans/issue-224.json
+++ b/.tiki/plans/issue-224.json
@@ -1,0 +1,62 @@
+{
+  "issue": {
+    "number": 224,
+    "title": "F: Write integrity — state.mjs lock + watcher active-project repoint"
+  },
+  "successCriteria": [
+    {
+      "id": "SC1",
+      "description": "Concurrent state.mjs writers never lose an update (cross-process lock around read-modify-write)",
+      "verified": true,
+      "verifiedAt": "2026-05-21T23:23:04.310Z"
+    },
+    {
+      "id": "SC2",
+      "description": "The desktop watcher observes the active project's .tiki after startup-restore, not just after a manual switch (no leftover cwd watcher / wrong-.tiki race)",
+      "verified": true,
+      "verifiedAt": "2026-05-21T23:23:04.310Z"
+    },
+    {
+      "id": "SC3",
+      "description": "pnpm build + framework node:test + cargo test + clippy --deny warnings all green",
+      "verified": true,
+      "verifiedAt": "2026-05-21T23:23:04.310Z"
+    }
+  ],
+  "coverageMatrix": {
+    "SC1": [
+      1
+    ],
+    "SC2": [
+      2
+    ],
+    "SC3": [
+      1,
+      2
+    ]
+  },
+  "phases": [
+    {
+      "number": 1,
+      "title": "Cross-process write lock in state.mjs",
+      "content": "Add withStateLock(tikiPath, fn) — exclusive lockfile (fs.openSync 'wx') with stale-steal (10s) + timeout (5s) + Atomics.wait sleep + process.on('exit') cleanup so die()/process.exit() never leaves a stale lock. Wrap the read-modify-write in handleTransition / handleRemove / handleAppendHistory (non-dry-run). Node built-ins only.",
+      "verification": [
+        "withStateLock wraps all three mutating handlers; dry-run still lock-free",
+        "state.test.mjs 'concurrent state.mjs writers do not lose updates' green (8 parallel appends, all survive, lockfile released)"
+      ],
+      "status": "completed",
+      "summary": "state.mjs withStateLock: exclusive lockfile + stale-steal + Atomics.wait + exit cleanup, wraps all 3 mutating handlers. Concurrent-writers test (8 parallel) green."
+    },
+    {
+      "number": 2,
+      "title": "Watcher active-project anchoring",
+      "content": "watcher.rs: fix start_watcher to store/pass the project ROOT (was passing cwd/.tiki → doubled to cwd/.tiki/.tiki); add is_superseded(current, mine) + a main-loop check so a watcher self-terminates when current_path moves on (fixes the stop_signal-vs-thread-startup race that left a cwd watcher emitting wrong-.tiki events after startup-restore). Skip .lock files in process_event.",
+      "verification": [
+        "start_watcher passes cwd root; main loop self-terminates on supersede",
+        "cargo test is_superseded_detects_project_switch green; clippy --deny warnings clean"
+      ],
+      "status": "completed",
+      "summary": "watcher.rs: start_watcher passes project root (fixes doubled .tiki); is_superseded + main-loop self-terminate fixes the startup-restore wrong-.tiki race; .lock files ignored."
+    }
+  ]
+}

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -62,16 +62,19 @@ pub enum TikiFileEvent {
 /// Start watching the .tiki directory for changes (initial startup)
 pub fn start_watcher(app_handle: AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     let cwd = std::env::current_dir()?;
-    let tiki_path = cwd.join(".tiki");
 
-    // Initialize state with current path
+    // current_path holds the project ROOT (start_watcher_internal appends
+    // `.tiki` itself). switch_watch_path stores the project root too, so the
+    // supersede check can compare like-for-like — previously start_watcher
+    // stored `cwd/.tiki`, which then became `cwd/.tiki/.tiki` and never matched
+    // a real directory (#224).
     {
         let state = get_watcher_state();
         let mut guard = state.lock().map_err(|e| e.to_string())?;
-        guard.current_path = Some(tiki_path.clone());
+        guard.current_path = Some(cwd.clone());
     }
 
-    start_watcher_internal(app_handle, tiki_path)
+    start_watcher_internal(app_handle, cwd)
 }
 
 /// Internal watcher implementation that can be restarted for different paths
@@ -141,6 +144,25 @@ fn start_watcher_internal(
         if stop_rx.try_recv().is_ok() {
             log::info!("Received stop signal, stopping watcher for {:?}", tiki_path);
             break;
+        }
+
+        // Self-terminate if a newer switch_watch_path has superseded us. The
+        // stop_signal hand-off races with thread startup (a switch fired right
+        // after launch can run before this thread stored its stop_signal), so
+        // we ALSO consult the authoritative current_path here. This guarantees
+        // only the active project's watcher survives — fixing the
+        // startup-restore "wrong .tiki" race (#224).
+        {
+            let state = get_watcher_state();
+            let superseded = state
+                .lock()
+                .map(|guard| is_superseded(guard.current_path.as_ref(), &project_path))
+                .unwrap_or(false);
+            drop(state);
+            if superseded {
+                log::info!("Watcher for {:?} superseded by a project switch; stopping", project_path);
+                break;
+            }
         }
 
         // Use recv_timeout to allow periodic stop-signal checks and to wake the
@@ -221,6 +243,17 @@ fn flush_quiet_events(
     }
 }
 
+/// A watcher is superseded when the authoritative `current_path` no longer
+/// points at the project this watcher was started for (a newer
+/// `switch_watch_path` won). `None` means no active path is recorded yet — don't
+/// self-terminate. Pure and unit-testable (the threaded race-fix for #224).
+fn is_superseded(current: Option<&PathBuf>, mine: &PathBuf) -> bool {
+    match current {
+        Some(p) => p != mine,
+        None => false,
+    }
+}
+
 /// Process a file system event and determine what Tiki event to emit
 fn process_event(event: &Event) -> Option<TikiFileEvent> {
     // Only care about modify/create/remove events
@@ -235,8 +268,9 @@ fn process_event(event: &Event) -> Option<TikiFileEvent> {
         if let Some(file_name) = path.file_name() {
             let name = file_name.to_string_lossy();
 
-            // Ignore temp files from atomic writes
-            if name.ends_with(".tmp") {
+            // Ignore temp files from atomic writes and the state.json.lock
+            // file used by the state.mjs write lock (#224).
+            if name.ends_with(".tmp") || name.ends_with(".lock") {
                 continue;
             }
 
@@ -329,6 +363,18 @@ mod tests {
         );
         let ready = quiet_keys(&pending, now, debounce);
         assert_eq!(ready, vec!["state".to_string()]);
+    }
+
+    #[test]
+    fn is_superseded_detects_project_switch() {
+        let a = PathBuf::from("/proj/a");
+        let b = PathBuf::from("/proj/b");
+        // Same path → still the active watcher, keep running.
+        assert!(!is_superseded(Some(&a), &a));
+        // A newer switch pointed current_path elsewhere → self-terminate.
+        assert!(is_superseded(Some(&b), &a));
+        // No active path recorded yet → don't self-terminate.
+        assert!(!is_superseded(None, &a));
     }
 
     #[test]

--- a/packages/framework/__tests__/state.test.mjs
+++ b/packages/framework/__tests__/state.test.mjs
@@ -18,7 +18,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawnSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { resolveTikiPath } from "../scripts/state.mjs";
@@ -385,5 +385,65 @@ test("phase is cleared when an issue transitions to completed (#220)", async () 
     parsed.activeWork["issue:6001"].phase,
     undefined,
     "phase must be cleared on completion (#220)"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Write-integrity lock (#224): concurrent read-modify-write must not lose an
+// update. Without the lock, interleaved writers clobber each other; with it,
+// every append survives.
+// ---------------------------------------------------------------------------
+
+test("concurrent state.mjs writers do not lose updates (#224 lock)", async () => {
+  const repo = await makeTmpDir("tiki-int-concurrent");
+  await fsp.mkdir(path.join(repo, ".git"), { recursive: true });
+  await fsp.mkdir(path.join(repo, ".tiki"), { recursive: true });
+
+  const N = 8;
+  const base = 5000;
+  // Launch all writers at once so their read-modify-write windows overlap.
+  const codes = await Promise.all(
+    Array.from({ length: N }, (_unused, i) => {
+      const num = base + i;
+      return new Promise((resolve, reject) => {
+        const child = spawn(
+          process.execPath,
+          [
+            STATE_SHIM,
+            "append-history",
+            "issue",
+            "--number",
+            String(num),
+            "--title",
+            `concurrent ${num}`,
+          ],
+          { cwd: repo }
+        );
+        child.on("exit", (code) => resolve(code));
+        child.on("error", reject);
+      });
+    })
+  );
+
+  assert.ok(
+    codes.every((c) => c === 0),
+    `every concurrent writer should exit 0 (got ${codes.join(",")})`
+  );
+
+  const stateFile = path.join(repo, ".tiki", "state.json");
+  const parsed = JSON.parse(await fsp.readFile(stateFile, "utf-8"));
+  const got = new Set((parsed.history.recentIssues || []).map((r) => r.number));
+  for (let i = 0; i < N; i++) {
+    assert.ok(
+      got.has(base + i),
+      `lost update under concurrency: issue ${base + i} missing (got ${[...got].join(",")})`
+    );
+  }
+
+  // The lock file must not linger after all writers release.
+  assert.equal(
+    fs.existsSync(path.join(repo, ".tiki", "state.json.lock")),
+    false,
+    "state.json.lock should be released after all writers finish"
   );
 });

--- a/packages/framework/scripts/state.mjs
+++ b/packages/framework/scripts/state.mjs
@@ -288,6 +288,107 @@ function writeStateAtomic(tikiPath, state) {
 }
 
 // ---------------------------------------------------------------------------
+// Cross-process write lock (#224).
+//
+// state.mjs is invoked once per transition, often chained rapidly during a
+// release cascade — and two processes doing read-modify-write on state.json can
+// interleave and LOSE an update (A reads, B reads, A writes, B writes; A's
+// mutation vanishes). writeStateAtomic's temp+rename only protects readers from
+// partial writes, not writers from clobbering each other. We serialize the whole
+// read-modify-write behind an exclusive lockfile.
+//
+// Node built-ins only (the Windows pnpm reparse-point block makes adding deps
+// painful — mirrors the node:test choice). Stale locks (from a crashed/killed
+// holder) are stolen after STALE_MS; an exit handler releases our own lock even
+// when die()/process.exit() unwinds past the finally.
+// ---------------------------------------------------------------------------
+
+let HELD_LOCK = null;
+
+function releaseHeldLock() {
+  if (!HELD_LOCK) return;
+  const { fd, path: lockPath } = HELD_LOCK;
+  HELD_LOCK = null;
+  try {
+    fs.closeSync(fd);
+  } catch {
+    /* ignore */
+  }
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    /* ignore */
+  }
+}
+
+// Fires on normal exit AND process.exit() (which die() calls), so an illegal
+// transition inside the lock never leaves the lockfile behind.
+process.on("exit", releaseHeldLock);
+
+/** Synchronous sleep with zero deps (no busy-spin). */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Run `fn` while holding an exclusive lock on `<tikiPath>/state.json.lock`.
+ * `fn` performs the read-modify-write; serializing it prevents lost updates.
+ */
+function withStateLock(tikiPath, fn) {
+  if (!fs.existsSync(tikiPath)) {
+    fs.mkdirSync(tikiPath, { recursive: true });
+  }
+  const lockPath = path.join(tikiPath, "state.json.lock");
+  const STALE_MS = 10_000;
+  const MAX_WAIT_MS = 5_000;
+  const RETRY_MS = 25;
+  const start = Date.now();
+
+  let fd = null;
+  for (;;) {
+    try {
+      fd = fs.openSync(lockPath, "wx"); // exclusive create — fails if held
+      break;
+    } catch (e) {
+      if (e.code !== "EEXIST") {
+        die(2, `failed to acquire state lock ${lockPath}: ${e.message}`);
+      }
+      // Lock is held. Steal it if the holder died and left it stale.
+      try {
+        const st = fs.statSync(lockPath);
+        if (Date.now() - st.mtimeMs > STALE_MS) {
+          try {
+            fs.unlinkSync(lockPath);
+          } catch {
+            /* another writer beat us to it */
+          }
+          continue;
+        }
+      } catch {
+        // Lock vanished between open and stat — retry immediately.
+        continue;
+      }
+      if (Date.now() - start > MAX_WAIT_MS) {
+        die(2, `timed out after ${MAX_WAIT_MS}ms waiting for state lock ${lockPath}`);
+      }
+      sleepSync(RETRY_MS);
+    }
+  }
+
+  try {
+    fs.writeSync(fd, String(process.pid));
+  } catch {
+    /* the pid is diagnostic only */
+  }
+  HELD_LOCK = { fd, path: lockPath };
+  try {
+    return fn();
+  } finally {
+    releaseHeldLock();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Shared helpers.
 // ---------------------------------------------------------------------------
 
@@ -496,25 +597,31 @@ function handleTransition(args) {
       }
     : null;
 
-  // Read existing state, apply, optionally write atomically.
+  // Read existing state, apply, optionally write atomically. The whole
+  // read-modify-write runs under the cross-process lock so chained writes
+  // during a release cascade can't lose an update (#224).
   const tikiPath = resolveTikiPath(args["tiki-path"]);
-  const state = readState(tikiPath);
   const dryRun = args["dry-run"] === true;
 
-  const updated = applyTransition(state, {
-    workId,
-    toStatus,
-    toStep: toStep || null,
-    phase,
-    parallelExecution: null, // not exposed via CLI yet — Rust IPC is canonical for parallel groups
-    parentRelease: parentRelease !== undefined ? parentRelease : undefined,
-    issue,
-    release,
-  });
-
-  if (!dryRun) {
-    writeStateAtomic(tikiPath, state);
-  }
+  let updated;
+  const apply = () => {
+    const state = readState(tikiPath);
+    updated = applyTransition(state, {
+      workId,
+      toStatus,
+      toStep: toStep || null,
+      phase,
+      parallelExecution: null, // not exposed via CLI yet — Rust IPC is canonical for parallel groups
+      parentRelease: parentRelease !== undefined ? parentRelease : undefined,
+      issue,
+      release,
+    });
+    if (!dryRun) {
+      writeStateAtomic(tikiPath, state);
+    }
+  };
+  if (dryRun) apply();
+  else withStateLock(tikiPath, apply);
 
   // Emit the updated entry as JSON to stdout. Callers can pipe / jq this.
   process.stdout.write(JSON.stringify(updated, null, 2) + "\n");
@@ -562,18 +669,23 @@ function handleRemove(args) {
   assertWorkIdShape(workId);
 
   const tikiPath = resolveTikiPath(args["tiki-path"]);
-  const state = readState(tikiPath);
-  state.activeWork = state.activeWork || {};
-  const entry = state.activeWork[workId];
-  if (!entry) {
-    die(1, `no active work for '${workId}'`);
-  }
-
-  delete state.activeWork[workId];
   const dryRun = args["dry-run"] === true;
-  if (!dryRun) {
-    writeStateAtomic(tikiPath, state);
-  }
+
+  let entry;
+  const apply = () => {
+    const state = readState(tikiPath);
+    state.activeWork = state.activeWork || {};
+    entry = state.activeWork[workId];
+    if (!entry) {
+      die(1, `no active work for '${workId}'`);
+    }
+    delete state.activeWork[workId];
+    if (!dryRun) {
+      writeStateAtomic(tikiPath, state);
+    }
+  };
+  if (dryRun) apply();
+  else withStateLock(tikiPath, apply);
 
   // Print the removed entry so callers can see what was deleted.
   process.stdout.write(JSON.stringify(entry, null, 2) + "\n");
@@ -641,41 +753,46 @@ function handleAppendHistory(args) {
   }
 
   const tikiPath = resolveTikiPath(args["tiki-path"]);
-  const state = readState(tikiPath);
-  state.history = state.history || {};
+  const dryRun = args["dry-run"] === true;
 
   let record;
-  if (kind === "issue") {
-    record = buildCompletedIssueRecord(args);
-    state.history.recentIssues = Array.isArray(state.history.recentIssues)
-      ? state.history.recentIssues
-      : [];
-    // Idempotent: drop any prior entry for the same issue number before
-    // re-inserting, so re-running append-history (e.g. ship.md during the
-    // cascade AND release.md teardown) never duplicates a child issue.
-    state.history.recentIssues = state.history.recentIssues.filter(
-      (entry) => entry == null || entry.number !== record.number
-    );
-    state.history.recentIssues.unshift(record);
-    state.history.lastCompletedIssue = record;
-  } else {
-    record = buildCompletedReleaseRecord(args);
-    state.history.recentReleases = Array.isArray(state.history.recentReleases)
-      ? state.history.recentReleases
-      : [];
-    // Idempotent: drop any prior entry for the same release version before
-    // re-inserting, so re-running append-history release never duplicates.
-    state.history.recentReleases = state.history.recentReleases.filter(
-      (entry) => entry == null || entry.version !== record.version
-    );
-    state.history.recentReleases.unshift(record);
-    state.history.lastCompletedRelease = record;
-  }
+  const apply = () => {
+    const state = readState(tikiPath);
+    state.history = state.history || {};
 
-  const dryRun = args["dry-run"] === true;
-  if (!dryRun) {
-    writeStateAtomic(tikiPath, state);
-  }
+    if (kind === "issue") {
+      record = buildCompletedIssueRecord(args);
+      state.history.recentIssues = Array.isArray(state.history.recentIssues)
+        ? state.history.recentIssues
+        : [];
+      // Idempotent: drop any prior entry for the same issue number before
+      // re-inserting, so re-running append-history (e.g. ship.md during the
+      // cascade AND release.md teardown) never duplicates a child issue.
+      state.history.recentIssues = state.history.recentIssues.filter(
+        (entry) => entry == null || entry.number !== record.number
+      );
+      state.history.recentIssues.unshift(record);
+      state.history.lastCompletedIssue = record;
+    } else {
+      record = buildCompletedReleaseRecord(args);
+      state.history.recentReleases = Array.isArray(state.history.recentReleases)
+        ? state.history.recentReleases
+        : [];
+      // Idempotent: drop any prior entry for the same release version before
+      // re-inserting, so re-running append-history release never duplicates.
+      state.history.recentReleases = state.history.recentReleases.filter(
+        (entry) => entry == null || entry.version !== record.version
+      );
+      state.history.recentReleases.unshift(record);
+      state.history.lastCompletedRelease = record;
+    }
+
+    if (!dryRun) {
+      writeStateAtomic(tikiPath, state);
+    }
+  };
+  if (dryRun) apply();
+  else withStateLock(tikiPath, apply);
 
   process.stdout.write(JSON.stringify(record, null, 2) + "\n");
 }


### PR DESCRIPTION
Wave 3 (part 1) of the status-desync epic (#218) — write-integrity hardening. Fully testable; #223 (the live-gated store consolidation) is the remaining Wave 3 item.

## Closes #224

**Lost-update race (state.mjs).** All three mutating handlers (`transition` / `remove` / `append-history`) did `readState → mutate → writeStateAtomic` with no lock; two processes chained during a release cascade could interleave and lose an update (the transient `exit 2` seen during v0.6.6 finalize). Added `withStateLock()` — an exclusive lockfile (`fs.openSync('wx')`) with stale-steal (10s), a 5s acquisition timeout, `Atomics.wait` sleep (no busy-spin), and a `process.on('exit')` release so a `die()`/crash never deadlocks. Node built-ins only.

**Watcher anchoring (watcher.rs).** `start_watcher` passed `cwd/.tiki` into `start_watcher_internal`, which re-appended `.tiki` → it watched `cwd/.tiki/.tiki`. Now passes the project root. Added `is_superseded()` + a main-loop self-termination check so a watcher whose project was switched away exits reliably — the `stop_signal` hand-off races with thread startup, so a watcher could otherwise keep emitting events from the wrong `.tiki` after startup-restore. `.lock` files are ignored by `process_event`.

## Verification
- `pnpm build` clean
- framework **24** (incl. new `concurrent state.mjs writers do not lose updates` — 8 parallel appends, all survive)
- Rust **31** (incl. `is_superseded_detects_project_switch`)
- desktop **177**, shared **86**, `cargo clippy --deny warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)