### PR TITLE
Collapse the dual activeWork store onto tikiStateStore (#223)

### DIFF
--- a/.tiki/plans/issue-223.json
+++ b/.tiki/plans/issue-223.json
@@ -1,0 +1,42 @@
+{
+  "issue": {
+    "number": 223,
+    "title": "E: Collapse the dual activeWork store (high risk)"
+  },
+  "successCriteria": [
+    { "id": "SC1", "description": "Every surface (Active Work sidebar, Kanban, detail, stale detection) reads activeWork from tikiStateStore — the React-local App.state.activeWork is no longer a render source" },
+    { "id": "SC2", "description": "Store activeWork selector returns a stable ref (store seeds {}), no inline ?? {} / ?? [] introduced in selector/hook-arg positions (guards the #210/#212 crash class)" },
+    { "id": "SC3", "description": "LIVE GATE: app boots and survives project-switch + empty-state in tauri:dev with NO render loop / blank screen" },
+    { "id": "SC4", "description": "pnpm build + desktop vitest green" }
+  ],
+  "coverageMatrix": {
+    "SC1": [1],
+    "SC2": [1],
+    "SC3": [2],
+    "SC4": [1]
+  },
+  "phases": [
+    {
+      "number": 1,
+      "title": "Route all surfaces to tikiStateStore.activeWork (single source)",
+      "content": "App.tsx: subscribe once via useTikiStateStore((s) => s.activeWork) and feed it to the three surface reads that previously used the React-local state.activeWork — staleFlags (useStaleWorkDetection), selectedIssueWork (detail), and StateSection (sidebar). KanbanBoard already reads the store. The store seeds activeWork to a stable {} ref so no inline ?? {} fallback is needed. Remove the now-dead EMPTY_ACTIVE_WORK constant. App-local `state` is retained only for the load guard + change-detection diffing (prevStateRef/currentState), not as a render source — eliminating the dual-source divergence.",
+      "verification": [
+        "grep: no remaining state.activeWork / state?.activeWork surface reads in App.tsx",
+        "EMPTY_ACTIVE_WORK removed (no unused-const build error)",
+        "pnpm build clean (tsc -b); desktop vitest 177 green"
+      ],
+      "status": "completed",
+      "summary": "App.tsx routes staleFlags + selectedIssueWork + StateSection to useTikiStateStore((s)=>s.activeWork); kanban already on the store. Dead EMPTY_ACTIVE_WORK removed. App-local state kept only for load guard + diffing. build clean, desktop 177."
+    },
+    {
+      "number": 2,
+      "title": "Live tauri:dev verification gate",
+      "content": "Run pnpm tauri:dev (Windows: from the x64 Native Tools Command Prompt for VS 2022). Confirm: (1) app boots to the normal UI, no blank screen / 'Maximum update depth exceeded'; (2) switching the active project re-renders sidebar+kanban+detail without a loop; (3) the empty-state (no active work) renders fine; (4) start/observe a piece of work so activeWork populates and all three surfaces show the SAME status. This is the gate static tests can't cover (the failure mode is a runtime render loop).",
+      "verification": [
+        "User confirms tauri:dev boots + survives project-switch + empty-state with no render loop",
+        "Sidebar, kanban, and detail show identical status for the same work item"
+      ],
+      "status": "pending"
+    }
+  ]
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -59,7 +59,8 @@ function scheduleRefresh(surface: RefreshSurface, fire: () => void): void {
 // Stable empty-fallback constants. Prevent fresh-object allocations in
 // hook arguments that would otherwise trigger infinite re-render loops
 // via useEffect dep instability (same bug class as #210 — see #212).
-const EMPTY_ACTIVE_WORK: Record<string, WorkContext> = {};
+// (activeWork now reads straight from tikiStateStore, whose initial value is
+// already a stable {} — so no EMPTY_ACTIVE_WORK fallback is needed here, #223.)
 const EMPTY_RECENT_ISSUES: Array<{ number: number; title?: string; completedAt: string }> = [];
 const EMPTY_RECENT_RELEASES: CompletedRelease[] = [];
 
@@ -174,7 +175,13 @@ function App() {
   const stalenessThresholdHours = useSettingsStore((s) => s.workflow.stalenessThresholdHours);
 
   // Stale work detection: flags issues whose last activity exceeds the threshold
-  const staleFlags = useStaleWorkDetection(state?.activeWork ?? EMPTY_ACTIVE_WORK, stalenessThresholdHours);
+  // Single source of truth for activeWork (#223): every surface — sidebar,
+  // kanban, detail, stale detection — reads tikiStateStore, so the React-local
+  // App.state copy no longer competes with the store. The store seeds
+  // activeWork to a stable {} ref, so no inline `?? {}` fallback is needed
+  // (that inline-fresh-ref pattern is the #210/#212 render-loop crash class).
+  const activeWork = useTikiStateStore((s) => s.activeWork);
+  const staleFlags = useStaleWorkDetection(activeWork, stalenessThresholdHours);
   useEffect(() => {
     const applyTheme = (resolved: 'dark' | 'light') => {
       document.documentElement.setAttribute('data-theme', resolved);
@@ -247,8 +254,8 @@ function App() {
   }, [selectedIssue, issueFromStore, activeProject?.path, detailRefreshNonce]);
 
   // Get work context for selected issue
-  const selectedIssueWork = selectedIssue && state?.activeWork
-    ? state.activeWork[`issue:${selectedIssue}`]
+  const selectedIssueWork = selectedIssue
+    ? activeWork[`issue:${selectedIssue}`] ?? null
     : null;
 
   // Hoisted into useCallback so the recovery dialog's `onRecovered` handler
@@ -534,7 +541,7 @@ function App() {
             <div className="sidebar-sections">
               {/* Active Work at the top for visibility */}
               {state && (
-                <StateSection activeWork={state.activeWork} staleFlags={staleFlags} />
+                <StateSection activeWork={activeWork} staleFlags={staleFlags} />
               )}
 
               {error && <div className="error">{error}</div>}


### PR DESCRIPTION
Wave 3 (part 2, final) of the status-desync epic (#218). **High risk — needs a live `tauri:dev` gate before merge** (the failure mode is a runtime render loop static tests don't catch).

## Closes #223

Every surface now reads `activeWork` from `tikiStateStore`: `staleFlags`, `selectedIssueWork` (detail), and the Active Work sidebar (`StateSection`). The Kanban already did. The React-local `App.state.activeWork` is no longer a render source, so the sidebar-vs-kanban divergence is gone.

- The store seeds `activeWork` to a stable `{}` ref, so `useTikiStateStore((s) => s.activeWork)` needs no inline `?? {}` fallback — that inline-fresh-ref pattern is the exact #210/#212 render-loop crash class. Removed the now-dead `EMPTY_ACTIVE_WORK` constant.
- `setActiveWork` is only called in effects (load/watcher), never during render → no loop.
- App-local `state` is retained solely for the load guard + change-detection diffing (`prevStateRef`/`currentState`), not as a render source.

## Verification
- `pnpm build` clean (tsc -b); desktop vitest **177**
- **Live gate (required before merge):** `pnpm tauri:dev` — boot + project-switch + empty-state with no render loop; sidebar/kanban/detail show identical status.

Ships as **v0.7.2** after the live gate passes (closes epic #218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)