### PR TITLE
fix(desktop): source PhaseStatus/WorkStatus/PipelineStep from @tiki/shared (#231)

### DIFF
--- a/apps/desktop/src/components/sidebar/WorkProgressCard.tsx
+++ b/apps/desktop/src/components/sidebar/WorkProgressCard.tsx
@@ -51,8 +51,8 @@ function getPhaseSegmentStatus(
   } else if (phaseNumber === currentPhase) {
     // Current phase - use the phase.status to determine if running or failed
     if (phaseStatus === "failed") return "failed";
-    if (phaseStatus === "running" || phaseStatus === "executing") return "running";
-    if (phaseStatus === "completed") return "completed";
+    if (phaseStatus === "executing") return "running";
+    if (phaseStatus === "completed" || phaseStatus === "skipped") return "completed";
     return "pending";
   } else {
     return "pending";
@@ -157,10 +157,9 @@ export function WorkProgressCard({ work, workId, isStale }: WorkProgressCardProp
       : null;
   // Disable while a phase is actively running — re-sending the command mid-phase
   // would queue a duplicate /tiki:execute behind the live one. PhaseStatus
-  // "executing" (and legacy "running") both represent in-flight phases.
+  // "executing" represents an in-flight phase.
   const isActivelyRunning =
-    work.status === "executing" &&
-    (phaseStatus === "executing" || phaseStatus === "running");
+    work.status === "executing" && phaseStatus === "executing";
   const resumeDisabled = resumeAction === null || isActivelyRunning;
 
   const handleResume = async (e: React.MouseEvent) => {

--- a/apps/desktop/src/components/work/WorkCard.tsx
+++ b/apps/desktop/src/components/work/WorkCard.tsx
@@ -1,6 +1,10 @@
-export type WorkStatus = "pending" | "reviewing" | "planning" | "executing" | "paused" | "completed" | "failed" | "shipping";
-export type PhaseStatus = "pending" | "running" | "executing" | "completed" | "failed";
-export type PipelineStep = "GET" | "REVIEW" | "PLAN" | "AUDIT" | "EXECUTE" | "SHIP";
+// Canonical status/pipeline unions live in @tiki/shared. Import them for local use AND
+// re-export so the existing `import ... from "../work/WorkCard"` sites keep working,
+// while @tiki/shared remains the single source of truth. Type-only → erased at build
+// (no runtime import). Fixes prior PhaseStatus drift: the local copy was missing
+// "skipped" and carried a non-canonical "running".
+import type { WorkStatus, PhaseStatus, PipelineStep } from "@tiki/shared";
+export type { WorkStatus, PhaseStatus, PipelineStep };
 
 export interface PhaseInfo {
   total: number;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -7,6 +7,8 @@
 export type {
   WorkStatus,
   PhaseStatus,
+  PipelineStep,
+  PipelineStepRecord,
   Timestamp,
   IssueInfo,
   PhaseProgress,


### PR DESCRIPTION
Fixes the confirmed `PhaseStatus` drift from #231 and removes the duplication that caused it.

## Problem
The desktop declared `@tiki/shared` as a dependency but imported it **0 times**, hand-re-declaring the status/pipeline unions. `WorkCard.tsx` `PhaseStatus` had drifted to `pending | running | executing | completed | failed` — a non-canonical `running` and **missing canonical `skipped`** (`packages/shared/src/types/state.ts`). A genuinely skipped phase was untyped on the frontend.

Root cause of the duplication: `PipelineStep` / `PipelineStepRecord` are defined in `state.ts` but were **never re-exported through the `@tiki/shared` types barrel**, so the desktop couldn't import them even though it depended on the package.

## Changes
- **`packages/shared/src/types/index.ts`** — export `PipelineStep` + `PipelineStepRecord` (close the public-API gap).
- **`apps/desktop/.../work/WorkCard.tsx`** — `import type` + `export type` the three unions from `@tiki/shared` (type-only → erased at build, honoring the "no `@tiki/shared` at runtime" policy). The three downstream import sites are unchanged.
- **`apps/desktop/.../sidebar/WorkProgressCard.tsx`** — the only `PhaseStatus` consumer: remove dead legacy `phaseStatus === "running"` comparisons (`executing` is canonical) and render `skipped` as resolved.

## Deliberately out of scope (separate design task)
`App.tsx`'s local `TikiState`, `IssueDetail`'s `TikiPlan`, and the `WorkContext`/`IssueContext`/`ReleaseContext` hierarchy are desktop **view models** that differ in *shape* from shared (e.g. `IssueContext.auditPassed?`, a trimmed `issue`, `TikiState` parameterized over the view model rather than shared `Work`). Unifying those is a design decision, not a mechanical swap, and is left for a follow-up.

Also intentionally untouched: `bulkYoloStore`'s `'running'` status — an unrelated, canonical type.

## Verification
- `pnpm build` (`tsc -b`, the stricter gate) — clean
- shared **86/86**, desktop **177/177**

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
