### PR TITLE
test(framework,desktop): cross-language parity for transition mutation body (#232)

### DIFF
--- a/apps/desktop/src-tauri/src/state_transition.rs
+++ b/apps/desktop/src-tauri/src/state_transition.rs
@@ -636,4 +636,57 @@ mod tests {
         let err = apply_transition(&mut state, input).expect_err("must reject");
         assert!(err.contains("invalid work_id"));
     }
+
+    /// Drop the volatile `lastActivity` field (both impls set it to "now") and
+    /// any null-valued keys so the two languages' serializations compare equal.
+    fn normalize_entry(v: &mut serde_json::Value) {
+        if let Some(obj) = v.as_object_mut() {
+            obj.remove("lastActivity");
+            obj.retain(|_, val| !val.is_null());
+        }
+    }
+
+    /// Behavioral-parity guard for the transition mutation BODY (#232).
+    ///
+    /// Consumes the SAME fixtures as the state.mjs CLI test
+    /// (packages/framework/__tests__/transition-mutation-parity.test.mjs):
+    /// `packages/shared/fixtures/transition-mutations.json`. Each fixture's
+    /// `before` state + `transition` is run through `apply_transition`, and the
+    /// resulting entry must equal the fixture's `expectedEntry`. If this Rust
+    /// impl drifts from the shared expectation (phase-clear-on-completion,
+    /// parallelExecution-clear, parentRelease preservation), this test fails;
+    /// if the Node impl drifts, the Node test fails. Together they keep the two
+    /// mirrors in lockstep beyond just the transition table.
+    #[test]
+    fn mutation_body_parity_fixtures() {
+        let raw =
+            include_str!("../../../../packages/shared/fixtures/transition-mutations.json");
+        let doc: serde_json::Value = serde_json::from_str(raw).expect("fixtures parse");
+        let cases = doc["cases"].as_array().expect("`cases` array");
+        assert!(!cases.is_empty(), "expected at least one parity fixture");
+
+        for case in cases {
+            let name = case["name"].as_str().unwrap_or("<unnamed>");
+            let work_id = case["workId"].as_str().expect("workId");
+
+            let mut state: TikiState = serde_json::from_value(case["before"].clone())
+                .unwrap_or_else(|e| panic!("[{}] before deserialize: {}", name, e));
+            let input: TransitionInput = serde_json::from_value(case["transition"].clone())
+                .unwrap_or_else(|e| panic!("[{}] transition deserialize: {}", name, e));
+
+            apply_transition(&mut state, input)
+                .unwrap_or_else(|e| panic!("[{}] apply_transition: {}", name, e));
+
+            let entry = state
+                .active_work
+                .get(work_id)
+                .unwrap_or_else(|| panic!("[{}] entry {} missing after transition", name, work_id));
+            let mut actual = serde_json::to_value(entry).expect("serialize entry");
+            let mut expected = case["expectedEntry"].clone();
+            normalize_entry(&mut actual);
+            normalize_entry(&mut expected);
+
+            assert_eq!(actual, expected, "mutation-body parity drift in case '{}'", name);
+        }
+    }
 }

--- a/packages/framework/__tests__/transition-mutation-parity.test.mjs
+++ b/packages/framework/__tests__/transition-mutation-parity.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * Behavioral-parity guard for the state-transition mutation BODY (#232).
+ *
+ * The transition TABLE is already guarded by
+ * packages/shared/src/__tests__/transitions-parity.test.ts. This guards the
+ * APPLY logic around it — phase-clear-on-completion, parallelExecution-clear,
+ * parentRelease preservation — which state.mjs and state_transition.rs
+ * implement independently.
+ *
+ * This test and the Rust unit test `mutation_body_parity_fixtures` (in
+ * apps/desktop/src-tauri/src/state_transition.rs) consume the SAME fixtures:
+ * packages/shared/fixtures/transition-mutations.json. The Node side exercises
+ * the real `state.mjs transition` CLI; the Rust side calls `apply_transition`
+ * directly. If either impl drifts from the shared expected result, that side
+ * fails — keeping the two mirrors in lockstep.
+ *
+ * node:test runner (zero devDeps — see CLAUDE.md on the Windows pnpm block).
+ */
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STATE_SHIM = path.resolve(__dirname, "..", "scripts", "state.mjs");
+const FIXTURES = path.resolve(__dirname, "..", "..", "shared", "fixtures", "transition-mutations.json");
+
+const tmpDirs = [];
+function makeTikiDir() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tiki-parity-"));
+  tmpDirs.push(root);
+  const tiki = path.join(root, ".tiki");
+  fs.mkdirSync(tiki, { recursive: true });
+  return tiki;
+}
+after(() => {
+  for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+});
+
+function runShim(tikiDir, args) {
+  return spawnSync(process.execPath, [STATE_SHIM, ...args, "--tiki-path", tikiDir], {
+    encoding: "utf8",
+  });
+}
+
+/** Drop the volatile lastActivity and any null/undefined keys (mirror of the
+ *  Rust test's normalize_entry) so the two languages compare equal. */
+function normalize(entry) {
+  const copy = { ...entry };
+  delete copy.lastActivity;
+  for (const k of Object.keys(copy)) {
+    if (copy[k] === null || copy[k] === undefined) delete copy[k];
+  }
+  return copy;
+}
+
+const fixtures = JSON.parse(fs.readFileSync(FIXTURES, "utf8"));
+assert.ok(Array.isArray(fixtures.cases) && fixtures.cases.length > 0, "fixtures must have cases");
+
+for (const c of fixtures.cases) {
+  test(`transition mutation parity: ${c.name}`, () => {
+    const tiki = makeTikiDir();
+    fs.writeFileSync(path.join(tiki, "state.json"), JSON.stringify(c.before, null, 2));
+
+    const t = c.transition;
+    const args = ["transition", c.workId, "--to-status", t.toStatus];
+    if (t.toStep) args.push("--to-step", t.toStep);
+    if (t.phase) {
+      args.push(
+        "--phase-current", String(t.phase.current),
+        "--phase-total", String(t.phase.total),
+        "--phase-status", t.phase.status,
+      );
+    }
+    if (t.parentRelease) args.push("--parent-release", t.parentRelease);
+
+    const res = runShim(tiki, args);
+    assert.equal(res.status, 0, `state.mjs transition failed: ${res.stderr || res.stdout}`);
+
+    const after = JSON.parse(fs.readFileSync(path.join(tiki, "state.json"), "utf8"));
+    const entry = after.activeWork[c.workId];
+    assert.ok(entry, `entry ${c.workId} missing after transition`);
+    assert.deepEqual(
+      normalize(entry),
+      normalize(c.expectedEntry),
+      `mutation-body parity drift in case '${c.name}'`,
+    );
+  });
+}
+
+test("append-history issue writes a CompletedIssueRecord-shaped entry", () => {
+  const tiki = makeTikiDir();
+  fs.writeFileSync(
+    path.join(tiki, "state.json"),
+    JSON.stringify({ schemaVersion: 1, activeWork: {} }, null, 2),
+  );
+
+  const res = runShim(tiki, [
+    "append-history", "issue",
+    "--number", "7",
+    "--title", "Foo",
+    "--completed-at", "2026-01-01T00:00:00.000Z",
+  ]);
+  assert.equal(res.status, 0, `append-history failed: ${res.stderr || res.stdout}`);
+
+  const state = JSON.parse(fs.readFileSync(path.join(tiki, "state.json"), "utf8"));
+  // Shape must match @tiki/shared CompletedIssueRecord: { number, title?, completedAt }.
+  const expected = { number: 7, title: "Foo", completedAt: "2026-01-01T00:00:00.000Z" };
+  assert.deepEqual(state.history.lastCompletedIssue, expected);
+  assert.deepEqual(state.history.recentIssues[0], expected);
+});

--- a/packages/shared/fixtures/transition-mutations.json
+++ b/packages/shared/fixtures/transition-mutations.json
@@ -1,0 +1,113 @@
+{
+  "_comment": "Shared behavioral-parity fixtures for the state-transition mutation BODY (#232). The transition TABLE is already guarded by transitions-parity.test.ts; this guards the apply logic that surrounds it: phase-clear-on-completion, parallelExecution-clear-on-shipping/completion, and parentRelease preservation. BOTH implementations consume these fixtures — apply_transition() in apps/desktop/src-tauri/src/state_transition.rs (Rust unit test) and the state.mjs CLI (packages/framework/__tests__/transition-mutation-parity.test.mjs). If either impl drifts from the shared expectation, that side's test fails. Comparison normalizes away `lastActivity` (both set it to now) and treats null-valued fields as absent. NOTE: transitions here never SET parallelExecution via the input, because the state.mjs CLI does not expose it (line ~614: 'Rust IPC is canonical for parallel groups'); we only test clearing an existing parallelExecution, which both paths do.",
+  "cases": [
+    {
+      "name": "executing->completed clears phase",
+      "workId": "issue:42",
+      "before": {
+        "schemaVersion": 1,
+        "activeWork": {
+          "issue:42": {
+            "type": "issue",
+            "issue": { "number": 42, "title": "Alpha" },
+            "status": "executing",
+            "pipelineStep": "EXECUTE",
+            "phase": { "current": 2, "total": 5, "status": "executing" },
+            "createdAt": "2026-01-01T00:00:00.000Z",
+            "lastActivity": "2026-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      "transition": { "workId": "issue:42", "toStatus": "completed", "toStep": "SHIP" },
+      "expectedEntry": {
+        "type": "issue",
+        "issue": { "number": 42, "title": "Alpha" },
+        "status": "completed",
+        "pipelineStep": "SHIP",
+        "createdAt": "2026-01-01T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "executing->shipping clears parallelExecution but keeps phase",
+      "workId": "issue:43",
+      "before": {
+        "schemaVersion": 1,
+        "activeWork": {
+          "issue:43": {
+            "type": "issue",
+            "issue": { "number": 43, "title": "Beta" },
+            "status": "executing",
+            "pipelineStep": "EXECUTE",
+            "phase": { "current": 3, "total": 6, "status": "executing" },
+            "parallelExecution": { "phases": [3, 4], "completedInGroup": [], "totalInGroup": 2, "startedAt": "2026-01-01T00:00:00.000Z" },
+            "createdAt": "2026-01-01T00:00:00.000Z",
+            "lastActivity": "2026-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      "transition": { "workId": "issue:43", "toStatus": "shipping", "toStep": "SHIP" },
+      "expectedEntry": {
+        "type": "issue",
+        "issue": { "number": 43, "title": "Beta" },
+        "status": "shipping",
+        "pipelineStep": "SHIP",
+        "phase": { "current": 3, "total": 6, "status": "executing" },
+        "createdAt": "2026-01-01T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "transition preserves existing parentRelease when none passed",
+      "workId": "issue:44",
+      "before": {
+        "schemaVersion": 1,
+        "activeWork": {
+          "issue:44": {
+            "type": "issue",
+            "issue": { "number": 44, "title": "Gamma" },
+            "status": "executing",
+            "pipelineStep": "EXECUTE",
+            "parentRelease": "v0.8.0",
+            "createdAt": "2026-01-01T00:00:00.000Z",
+            "lastActivity": "2026-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      "transition": { "workId": "issue:44", "toStatus": "shipping", "toStep": "SHIP" },
+      "expectedEntry": {
+        "type": "issue",
+        "issue": { "number": 44, "title": "Gamma" },
+        "status": "shipping",
+        "pipelineStep": "SHIP",
+        "parentRelease": "v0.8.0",
+        "createdAt": "2026-01-01T00:00:00.000Z"
+      }
+    },
+    {
+      "name": "same-state executing->executing updates phase progress",
+      "workId": "issue:45",
+      "before": {
+        "schemaVersion": 1,
+        "activeWork": {
+          "issue:45": {
+            "type": "issue",
+            "issue": { "number": 45, "title": "Delta" },
+            "status": "executing",
+            "pipelineStep": "EXECUTE",
+            "phase": { "current": 1, "total": 5, "status": "executing" },
+            "createdAt": "2026-01-01T00:00:00.000Z",
+            "lastActivity": "2026-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      "transition": { "workId": "issue:45", "toStatus": "executing", "toStep": "EXECUTE", "phase": { "current": 3, "total": 5, "status": "executing" } },
+      "expectedEntry": {
+        "type": "issue",
+        "issue": { "number": 45, "title": "Delta" },
+        "status": "executing",
+        "pipelineStep": "EXECUTE",
+        "phase": { "current": 3, "total": 5, "status": "executing" },
+        "createdAt": "2026-01-01T00:00:00.000Z"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Extends parity testing from the transition **table** to the mutation **body** — the apply logic that `state.mjs` and `state_transition.rs` each implement independently.

## Why
`transitions-parity.test.ts` already guards the table (a declarative Set, comparable by parsing source). But the imperative apply-logic — **phase-clear-on-completion** (#220), **parallelExecution-clear-on-shipping/completion**, **parentRelease preservation** — can't be textually compared across Rust and JS, and has drifted before. This adds a behavioral guard.

## How
One shared fixtures file, two harnesses running it:
- **`packages/shared/fixtures/transition-mutations.json`** — `before` state + `transition` + `expectedEntry`, 4 cases covering the three rules (+ a same-state phase update).
- **Rust** (`state_transition.rs` → `mutation_body_parity_fixtures`) — `include_str!`s the fixtures and runs each through `apply_transition()`.
- **Node** (`packages/framework/__tests__/transition-mutation-parity.test.mjs`) — runs the same fixtures through the real `state.mjs transition` CLI, in a temp `.tiki`.

Comparison normalizes away the volatile `lastActivity` and null-valued keys. If either mirror drifts from the shared expectation, that side fails.

Also adds an `append-history issue` test asserting the written record matches the `@tiki/shared` `CompletedIssueRecord` shape (`{ number, title, completedAt }`) — the Kanban-Completed-column contract that previously lived only in `state.mjs` + `ship.md` prose.

### Scope note
Fixtures never *set* `parallelExecution` via the transition input, because the `state.mjs` CLI deliberately doesn't expose it (`parallelExecution: null` — "Rust IPC is canonical for parallel groups"). Only *clearing* an existing one is tested, which both paths do identically.

## Verification
- Node framework tests **28 → 33**
- Rust lib tests **42 → 43**
- `cargo clippy --all-targets -- --deny warnings` clean

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
