### PR TITLE
refactor(desktop): decompose App.tsx into hooks (#234)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
-import { listen } from "@tauri-apps/api/event";
 import { Panel, Separator, Group } from "react-resizable-panels";
 import { MotionConfig } from "framer-motion";
 import { checkForAppUpdates } from "./utils/updater";
@@ -22,131 +21,14 @@ import { ToastContainer } from "./components/ui/ToastContainer";
 import { BulkActionToolbar } from "./components/BulkActionToolbar";
 import { BulkYoloDialog } from "./components/BulkYoloDialog";
 import { CommandPalette, ErrorBoundary, KeyboardShortcuts } from "./components/ui";
-import { useCommandActions, useStaleWorkDetection } from "./hooks";
+import { useCommandActions, useStaleWorkDetection, useTikiFileSync, useGithubFreshness, useBulkYoloCascade } from "./hooks";
 import { StateRecoveryDialog } from "./components/recovery";
-import type { WorkContext } from "./components/work";
-import { useLayoutStore, useDetailStore, useIssuesStore, useReleasesStore, useProjectsStore, useTikiReleasesStore, useTikiStateStore, useTerminalStore, useToastStore, usePullRequestsStore, useCommandPaletteStore, useResearchStore, useSettingsStore, useBulkYoloStore, type CompletedRelease } from "./stores";
-import type { GitHubIssue, ResearchDocMeta, TikiRelease } from "./stores";
+import { useLayoutStore, useDetailStore, useIssuesStore, useReleasesStore, useProjectsStore, useTikiReleasesStore, useTikiStateStore, useTerminalStore, usePullRequestsStore, useCommandPaletteStore, useSettingsStore } from "./stores";
+import type { GitHubIssue } from "./stores";
 import { terminalFocusRegistry } from "./stores/terminalStore";
-import { detectGithubRefreshTriggers } from "./utils/githubRefreshTriggers";
-import { dispatchNextBulkYolo } from "./utils/bulkYoloDispatch";
-import { shouldRefreshOnVisibility, canIntervalPoll, effectiveIntervalMs } from "./utils/githubFreshness";
-import type { RateLimitStatus } from "./components/RateLimitIndicator";
+import { syncTikiStateStore, type TikiState } from "./utils/tikiStateSync";
 import "./App.css";
 import "./components/layout/layout.css";
-
-// Per-surface trailing-edge debounce for GitHub re-fetches triggered by
-// state.json transitions. The watcher already coalesces filesystem-level
-// events, but logical events (e.g. shipping a 5-issue release writes
-// state.json many times in quick succession) still produce N triggers per
-// surface. 500ms trailing-edge collapses that to one fetch per surface.
-type RefreshSurface = 'issues' | 'prs' | 'releases';
-const pendingRefreshTriggers: Map<RefreshSurface, ReturnType<typeof setTimeout>> = new Map();
-const REFRESH_DEBOUNCE_MS = 500;
-
-function scheduleRefresh(surface: RefreshSurface, fire: () => void): void {
-  const existing = pendingRefreshTriggers.get(surface);
-  if (existing) clearTimeout(existing);
-  pendingRefreshTriggers.set(
-    surface,
-    setTimeout(() => {
-      pendingRefreshTriggers.delete(surface);
-      fire();
-    }, REFRESH_DEBOUNCE_MS),
-  );
-}
-
-// Stable empty-fallback constants. Prevent fresh-object allocations in
-// hook arguments that would otherwise trigger infinite re-render loops
-// via useEffect dep instability (same bug class as #210 — see #212).
-// (activeWork now reads straight from tikiStateStore, whose initial value is
-// already a stable {} — so no EMPTY_ACTIVE_WORK fallback is needed here, #223.)
-const EMPTY_RECENT_ISSUES: Array<{ number: number; title?: string; completedAt: string }> = [];
-const EMPTY_RECENT_RELEASES: CompletedRelease[] = [];
-
-// Normalize raw history.recentReleases (where `issues` may be absent) into the
-// store's CompletedRelease shape (`issues: number[]`). Returns the stable
-// EMPTY_RECENT_RELEASES const when there is nothing, so consumers never see a
-// fresh empty-array ref (same fresh-ref bug class as #210/#212).
-function normalizeRecentReleases(
-  raw: Array<{ version: string; issues?: number[]; completedAt: string; tag?: string }> | undefined,
-): CompletedRelease[] {
-  if (!raw || raw.length === 0) return EMPTY_RECENT_RELEASES;
-  return raw.map((r) => ({
-    version: r.version,
-    issues: r.issues ?? [],
-    completedAt: r.completedAt,
-    ...(r.tag !== undefined ? { tag: r.tag } : {}),
-  }));
-}
-
-// Types matching Rust state structures
-interface TikiState {
-  schemaVersion: number;
-  activeWork: Record<string, WorkContext>;
-  history?: {
-    lastCompletedIssue?: { number: number; title?: string; completedAt: string };
-    lastCompletedRelease?: { version: string; completedAt: string };
-    recentIssues?: Array<{ number: number; title?: string; completedAt: string }>;
-    recentReleases?: Array<{ version: string; issues?: number[]; completedAt: string; tag?: string }>;
-  };
-}
-
-interface FileEvent {
-  type: "stateChanged" | "planChanged" | "releaseChanged" | "researchChanged";
-  issueNumber?: number;
-  version?: string;
-  filename?: string;
-}
-
-function detectStateChanges(
-  oldState: TikiState | null,
-  newState: TikiState | null,
-) {
-  if (!oldState || !newState) return;
-  const addToast = useToastStore.getState().addToast;
-  const oldWork = oldState.activeWork;
-  const newWork = newState.activeWork;
-
-  for (const [workId, newItem] of Object.entries(newWork)) {
-    const oldItem = oldWork[workId];
-    if (!oldItem) continue;
-
-    // Detect status changes
-    if (oldItem.status !== newItem.status) {
-      if (newItem.status === 'completed' && newItem.type === 'issue') {
-        addToast(`Issue #${newItem.issue.number} completed`, 'success', 5000);
-      } else if (newItem.status === 'failed' && newItem.type === 'issue') {
-        addToast(`Issue #${newItem.issue.number} failed`, 'error', 8000);
-      } else if (newItem.status === 'shipping' && newItem.type === 'issue') {
-        addToast(`Shipping issue #${newItem.issue.number}...`, 'info', 3000);
-      }
-    }
-
-    // Detect phase completion for issues
-    if (newItem.type === 'issue' && oldItem.type === 'issue') {
-      const oldPhase = oldItem.phase;
-      const newPhase = newItem.phase;
-      if (oldPhase && newPhase && oldPhase.current !== newPhase.current && newPhase.current > oldPhase.current) {
-        addToast(`Phase ${newPhase.current}/${newPhase.total} completed`, 'success', 4000);
-      }
-    }
-
-    // Detect pipeline step transitions
-    if (oldItem.pipelineStep !== newItem.pipelineStep) {
-      if (oldItem.pipelineStep === 'AUDIT' && newItem.pipelineStep === 'EXECUTE') {
-        addToast('Audit passed', 'success', 3000);
-      }
-    }
-  }
-
-  // Detect work removed from activeWork (completed and moved to history)
-  for (const [workId, oldItem] of Object.entries(oldWork)) {
-    if (!newWork[workId] && oldItem.type === 'issue') {
-      addToast(`Issue #${oldItem.issue.number} shipped`, 'success', 5000);
-    }
-  }
-}
 
 function App() {
   const [state, setState] = useState<TikiState | null>(null);
@@ -219,6 +101,9 @@ function App() {
   // Bumped on every state.json change so the on-demand issue fetch below
   // re-runs and the detail GitHub badge updates without a reselection (#220).
   const [detailRefreshNonce, setDetailRefreshNonce] = useState(0);
+  // Stable bump for the detail nonce — passed to the file-sync and
+  // github-freshness hooks so their effects don't re-subscribe each render (#234).
+  const bumpDetailRefresh = useCallback(() => setDetailRefreshNonce((n) => n + 1), []);
   const issueFromStore = selectedIssue
     ? issues.find((i) => i.number === selectedIssue) ?? null
     : null;
@@ -273,13 +158,8 @@ function App() {
         prevStateRef.current = currentState;
         setState(currentState);
         setRecoveryError(null);
-        // Sync to tikiStateStore for Kanban
-        if (currentState?.activeWork) {
-          useTikiStateStore.getState().setActiveWork(currentState.activeWork);
-        }
-        // Sync recentIssues + recentReleases for Completed column
-        useTikiStateStore.getState().setRecentIssues(currentState?.history?.recentIssues ?? EMPTY_RECENT_ISSUES);
-        useTikiStateStore.getState().setRecentReleases(normalizeRecentReleases(currentState?.history?.recentReleases));
+        // Sync parsed state into tikiStateStore (Kanban / Completed column).
+        syncTikiStateStore(currentState);
       } catch (e) {
         console.error("Error loading state:", e);
         setError(String(e));
@@ -301,13 +181,8 @@ function App() {
       prevStateRef.current = currentState;
       setState(currentState);
       setRecoveryError(null);
-      // Sync to tikiStateStore for Kanban
-      if (currentState?.activeWork) {
-        useTikiStateStore.getState().setActiveWork(currentState.activeWork);
-      }
-      // Sync recentIssues + recentReleases for Completed column
-      useTikiStateStore.getState().setRecentIssues(currentState?.history?.recentIssues ?? EMPTY_RECENT_ISSUES);
-      useTikiStateStore.getState().setRecentReleases(normalizeRecentReleases(currentState?.history?.recentReleases));
+      // Sync parsed state into tikiStateStore (Kanban / Completed column).
+      syncTikiStateStore(currentState);
     } catch (e) {
       console.error("Error loading state:", e);
       setError(String(e));
@@ -320,150 +195,13 @@ function App() {
     void loadState();
   }, [loadState]);
 
-  // GitHub freshness (#221): the watcher only watches .tiki/, so issues/PRs/
-  // releases closed outside the app stay stale. Re-sync on window focus / tab
-  // visibility (default on) and, optionally, on a rate-limit-gated interval
-  // (off by default).
-  const githubFocusRefresh = useSettingsStore((s) => s.github.focusRefresh);
-  const githubPollSeconds = useSettingsStore((s) => s.github.pollIntervalSeconds);
-  useEffect(() => {
-    const refreshAll = () => {
-      scheduleRefresh('issues', () => useIssuesStore.getState().triggerRefetch());
-      scheduleRefresh('prs', () => usePullRequestsStore.getState().triggerRefetch());
-      scheduleRefresh('releases', () => useReleasesStore.getState().triggerRefetch());
-      // Invalidate the detail single-issue cache too (pairs with #220).
-      setDetailRefreshNonce((n) => n + 1);
-    };
-
-    const onVisibility = () => {
-      if (shouldRefreshOnVisibility(githubFocusRefresh ?? true, document.visibilityState)) {
-        refreshAll();
-      }
-    };
-    window.addEventListener('focus', onVisibility);
-    document.addEventListener('visibilitychange', onVisibility);
-
-    // Optional periodic poll — off by default, rate-limit-gated when enabled.
-    const intervalMs = effectiveIntervalMs(githubPollSeconds);
-    let timer: number | null = null;
-    if (intervalMs !== null) {
-      timer = window.setInterval(() => {
-        void invoke<RateLimitStatus>('fetch_rate_limit_status', { projectPath: null })
-          .then((status) => { if (canIntervalPoll(status)) refreshAll(); })
-          .catch(() => { if (canIntervalPoll(null)) refreshAll(); });
-      }, intervalMs);
-    }
-
-    return () => {
-      window.removeEventListener('focus', onVisibility);
-      document.removeEventListener('visibilitychange', onVisibility);
-      if (timer !== null) window.clearInterval(timer);
-    };
-  }, [githubFocusRefresh, githubPollSeconds]);
-
-  // Listen for file changes
-  useEffect(() => {
-    const unlisten = listen<FileEvent>("tiki-file-changed", async (event) => {
-      console.log("File changed:", event.payload);
-      if (event.payload.type === "stateChanged") {
-        try {
-          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
-          const currentState = await invoke<TikiState | null>("get_state", {
-            tikiPath: projectTikiPath,
-          });
-          console.log("State reloaded, activeWork keys:", currentState?.activeWork ? Object.keys(currentState.activeWork) : 'none');
-          const prev = prevStateRef.current;
-          detectStateChanges(prev, currentState);
-          // Re-fetch the open detail issue's GitHub state on every state
-          // change so a close-elsewhere (e.g. release-child ship) updates the
-          // badge without reselection (#220, pairs with deriveDisplayStatus).
-          setDetailRefreshNonce((n) => n + 1);
-          // Detect activeWork → history transitions to drive sidebar GitHub re-fetches
-          // (issue close, release ship). Debounced per-surface to coalesce bursts.
-          if (prev && currentState) {
-            const triggers = detectGithubRefreshTriggers(prev, currentState);
-            if (triggers.issuesRefresh) {
-              scheduleRefresh('issues', () => useIssuesStore.getState().triggerRefetch());
-            }
-            if (triggers.prsRefresh) {
-              scheduleRefresh('prs', () => usePullRequestsStore.getState().triggerRefetch());
-            }
-            if (triggers.releasesRefresh) {
-              scheduleRefresh('releases', () => useReleasesStore.getState().triggerRefetch());
-            }
-
-            // Bulk YOLO cascade: when state.json transitions the run's
-            // current issue from activeWork into history, advance the
-            // queue and dispatch the next /tiki:yolo. Detect failure
-            // (activeWork[issue].status === 'failed') and pause + toast.
-            const projectId =
-              useProjectsStore.getState().activeProjectId ?? 'default';
-            const bulkRun =
-              useBulkYoloStore.getState().runByProject[projectId] ?? null;
-            if (bulkRun && bulkRun.status === 'running') {
-              const currentIssue = bulkRun.queue[bulkRun.currentIndex];
-              if (currentIssue !== undefined) {
-                const wasActive =
-                  `issue:${currentIssue}` in (prev.activeWork ?? {});
-                const nowDone = (
-                  currentState.history?.recentIssues ?? EMPTY_RECENT_ISSUES
-                ).some((i) => i.number === currentIssue);
-                const nowFailed =
-                  currentState.activeWork?.[`issue:${currentIssue}`]
-                    ?.status === 'failed';
-
-                if (wasActive && nowDone) {
-                  // Issue shipped — advance the queue and dispatch the next.
-                  useBulkYoloStore.getState().advance();
-                  void dispatchNextBulkYolo(projectId);
-                } else if (nowFailed) {
-                  useBulkYoloStore
-                    .getState()
-                    .recordFailure(`Issue #${currentIssue} pipeline failed`);
-                  useToastStore.getState().addToast(
-                    `Bulk YOLO paused: issue #${currentIssue} failed. Fix and resume from the dialog.`,
-                    'error',
-                  );
-                }
-              }
-            }
-          }
-          prevStateRef.current = currentState;
-          setState(currentState);
-          // Sync to tikiStateStore for Kanban
-          if (currentState?.activeWork) {
-            console.log("Syncing to tikiStateStore:", Object.entries(currentState.activeWork).map(([k, v]) => `${k}: ${v.status}`));
-            useTikiStateStore.getState().setActiveWork(currentState.activeWork);
-          }
-          // Sync recentIssues + recentReleases for Completed column
-          useTikiStateStore.getState().setRecentIssues(currentState?.history?.recentIssues ?? EMPTY_RECENT_ISSUES);
-          useTikiStateStore.getState().setRecentReleases(normalizeRecentReleases(currentState?.history?.recentReleases));
-        } catch (e) {
-          console.error("Failed to reload state:", e);
-        }
-      } else if (event.payload.type === "releaseChanged") {
-        try {
-          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
-          const loadedReleases = await invoke<TikiRelease[]>("load_tiki_releases", { tikiPath: projectTikiPath });
-          useTikiReleasesStore.getState().setReleases(loadedReleases);
-        } catch (e) {
-          console.error("Failed to reload releases:", e);
-        }
-      } else if (event.payload.type === "researchChanged") {
-        try {
-          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
-          const loadedDocs = await invoke<ResearchDocMeta[]>("list_research_docs", { tikiPath: projectTikiPath });
-          useResearchStore.getState().setDocs(loadedDocs);
-        } catch (e) {
-          console.error("Failed to reload research docs:", e);
-        }
-      }
-    });
-
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [activeProject]);
+  // Watcher → frontend sync, GitHub freshness, and the bulk-YOLO cascade —
+  // extracted from inline effects into hooks (#234). The cascade callback and
+  // bumpDetailRefresh are stable, so these effects re-subscribe only on
+  // activeProject / settings change, preserving the original behavior.
+  const advanceBulkYolo = useBulkYoloCascade();
+  useTikiFileSync({ activeProject, prevStateRef, setState, bumpDetailRefresh, onStateChange: advanceBulkYolo });
+  useGithubFreshness(bumpDetailRefresh);
 
   const handleResetLayout = () => {
     useLayoutStore.getState().resetLayout();

--- a/apps/desktop/src/hooks/index.ts
+++ b/apps/desktop/src/hooks/index.ts
@@ -1,2 +1,5 @@
 export { useCommandActions } from './useCommandActions';
 export { useStaleWorkDetection } from './useStaleWorkDetection';
+export { useTikiFileSync } from './useTikiFileSync';
+export { useGithubFreshness } from './useGithubFreshness';
+export { useBulkYoloCascade } from './useBulkYoloCascade';

--- a/apps/desktop/src/hooks/useBulkYoloCascade.ts
+++ b/apps/desktop/src/hooks/useBulkYoloCascade.ts
@@ -1,0 +1,15 @@
+// Bulk-YOLO cascade hook (#234). Returns a stable callback that advances the
+// cascade on a state change, backed by the pure (unit-tested)
+// advanceBulkYoloOnStateChange. Wiring it through a hook keeps App.tsx's
+// concerns symmetric (one hook per extracted concern) while the logic stays
+// testable without React.
+
+import { useCallback } from "react";
+import { advanceBulkYoloOnStateChange } from "../utils/bulkYoloCascade";
+import type { TikiState } from "../utils/tikiStateSync";
+
+export function useBulkYoloCascade(): (prev: TikiState, next: TikiState) => void {
+  return useCallback((prev: TikiState, next: TikiState) => {
+    advanceBulkYoloOnStateChange(prev, next);
+  }, []);
+}

--- a/apps/desktop/src/hooks/useGithubFreshness.ts
+++ b/apps/desktop/src/hooks/useGithubFreshness.ts
@@ -1,0 +1,51 @@
+// GitHub freshness (#221, extracted from App.tsx in #234). The watcher only
+// watches .tiki/, so issues/PRs/releases closed outside the app stay stale.
+// Re-sync on window focus / tab visibility (default on) and, optionally, on a
+// rate-limit-gated interval (off by default).
+
+import { useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useSettingsStore, useIssuesStore, usePullRequestsStore, useReleasesStore } from "../stores";
+import { scheduleRefresh } from "../utils/scheduleRefresh";
+import { shouldRefreshOnVisibility, canIntervalPoll, effectiveIntervalMs } from "../utils/githubFreshness";
+import type { RateLimitStatus } from "../components/RateLimitIndicator";
+
+export function useGithubFreshness(bumpDetailRefresh: () => void): void {
+  const githubFocusRefresh = useSettingsStore((s) => s.github.focusRefresh);
+  const githubPollSeconds = useSettingsStore((s) => s.github.pollIntervalSeconds);
+
+  useEffect(() => {
+    const refreshAll = () => {
+      scheduleRefresh('issues', () => useIssuesStore.getState().triggerRefetch());
+      scheduleRefresh('prs', () => usePullRequestsStore.getState().triggerRefetch());
+      scheduleRefresh('releases', () => useReleasesStore.getState().triggerRefetch());
+      // Invalidate the detail single-issue cache too (pairs with #220).
+      bumpDetailRefresh();
+    };
+
+    const onVisibility = () => {
+      if (shouldRefreshOnVisibility(githubFocusRefresh ?? true, document.visibilityState)) {
+        refreshAll();
+      }
+    };
+    window.addEventListener('focus', onVisibility);
+    document.addEventListener('visibilitychange', onVisibility);
+
+    // Optional periodic poll — off by default, rate-limit-gated when enabled.
+    const intervalMs = effectiveIntervalMs(githubPollSeconds);
+    let timer: number | null = null;
+    if (intervalMs !== null) {
+      timer = window.setInterval(() => {
+        void invoke<RateLimitStatus>('fetch_rate_limit_status', { projectPath: null })
+          .then((status) => { if (canIntervalPoll(status)) refreshAll(); })
+          .catch(() => { if (canIntervalPoll(null)) refreshAll(); });
+      }, intervalMs);
+    }
+
+    return () => {
+      window.removeEventListener('focus', onVisibility);
+      document.removeEventListener('visibilitychange', onVisibility);
+      if (timer !== null) window.clearInterval(timer);
+    };
+  }, [githubFocusRefresh, githubPollSeconds, bumpDetailRefresh]);
+}

--- a/apps/desktop/src/hooks/useTikiFileSync.ts
+++ b/apps/desktop/src/hooks/useTikiFileSync.ts
@@ -1,0 +1,111 @@
+// Wires the Rust watcher's `tiki-file-changed` events into the frontend (#234,
+// extracted from App.tsx). On a state change it reloads state.json, emits
+// transition toasts, drives debounced GitHub re-fetches, advances the bulk-YOLO
+// cascade, and syncs tikiStateStore. Release/research changes reload their
+// stores.
+
+import { useEffect, type Dispatch, type SetStateAction, type RefObject } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import {
+  useIssuesStore,
+  usePullRequestsStore,
+  useReleasesStore,
+  useTikiReleasesStore,
+  useResearchStore,
+  type ResearchDocMeta,
+  type TikiRelease,
+} from "../stores";
+import { scheduleRefresh } from "../utils/scheduleRefresh";
+import { detectGithubRefreshTriggers } from "../utils/githubRefreshTriggers";
+import { detectStateChanges, syncTikiStateStore, type TikiState } from "../utils/tikiStateSync";
+
+interface FileEvent {
+  type: "stateChanged" | "planChanged" | "releaseChanged" | "researchChanged";
+  issueNumber?: number;
+  version?: string;
+  filename?: string;
+}
+
+interface UseTikiFileSyncParams {
+  /** Active project (or null/undefined for the default cwd-based path). */
+  activeProject: { path: string } | null | undefined;
+  /** App's previous-state ref, updated after each reload for change detection. */
+  prevStateRef: RefObject<TikiState | null>;
+  /** App's state setter — the reloaded state is pushed here for rendering. */
+  setState: Dispatch<SetStateAction<TikiState | null>>;
+  /** Bump the detail-panel refresh nonce (re-fetches the open issue's GH state). */
+  bumpDetailRefresh: () => void;
+  /** Called with (prev, next) on every state change — drives the bulk-YOLO cascade. */
+  onStateChange: (prev: TikiState, next: TikiState) => void;
+}
+
+export function useTikiFileSync({
+  activeProject,
+  prevStateRef,
+  setState,
+  bumpDetailRefresh,
+  onStateChange,
+}: UseTikiFileSyncParams): void {
+  useEffect(() => {
+    const unlisten = listen<FileEvent>("tiki-file-changed", async (event) => {
+      console.log("File changed:", event.payload);
+      if (event.payload.type === "stateChanged") {
+        try {
+          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
+          const currentState = await invoke<TikiState | null>("get_state", {
+            tikiPath: projectTikiPath,
+          });
+          console.log("State reloaded, activeWork keys:", currentState?.activeWork ? Object.keys(currentState.activeWork) : 'none');
+          const prev = prevStateRef.current;
+          detectStateChanges(prev, currentState);
+          // Re-fetch the open detail issue's GitHub state on every state change
+          // so a close-elsewhere (e.g. release-child ship) updates the badge
+          // without reselection (#220, pairs with deriveDisplayStatus).
+          bumpDetailRefresh();
+          // Detect activeWork → history transitions to drive sidebar GitHub
+          // re-fetches (issue close, release ship). Debounced per-surface.
+          if (prev && currentState) {
+            const triggers = detectGithubRefreshTriggers(prev, currentState);
+            if (triggers.issuesRefresh) {
+              scheduleRefresh('issues', () => useIssuesStore.getState().triggerRefetch());
+            }
+            if (triggers.prsRefresh) {
+              scheduleRefresh('prs', () => usePullRequestsStore.getState().triggerRefetch());
+            }
+            if (triggers.releasesRefresh) {
+              scheduleRefresh('releases', () => useReleasesStore.getState().triggerRefetch());
+            }
+            // Bulk-YOLO cascade: advance the queue / pause on failure.
+            onStateChange(prev, currentState);
+          }
+          prevStateRef.current = currentState;
+          setState(currentState);
+          syncTikiStateStore(currentState);
+        } catch (e) {
+          console.error("Failed to reload state:", e);
+        }
+      } else if (event.payload.type === "releaseChanged") {
+        try {
+          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
+          const loadedReleases = await invoke<TikiRelease[]>("load_tiki_releases", { tikiPath: projectTikiPath });
+          useTikiReleasesStore.getState().setReleases(loadedReleases);
+        } catch (e) {
+          console.error("Failed to reload releases:", e);
+        }
+      } else if (event.payload.type === "researchChanged") {
+        try {
+          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
+          const loadedDocs = await invoke<ResearchDocMeta[]>("list_research_docs", { tikiPath: projectTikiPath });
+          useResearchStore.getState().setDocs(loadedDocs);
+        } catch (e) {
+          console.error("Failed to reload research docs:", e);
+        }
+      }
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [activeProject, prevStateRef, setState, bumpDetailRefresh, onStateChange]);
+}

--- a/apps/desktop/src/utils/__tests__/bulkYoloCascade.test.ts
+++ b/apps/desktop/src/utils/__tests__/bulkYoloCascade.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { advanceBulkYoloOnStateChange } from '../bulkYoloCascade';
+import { useBulkYoloStore } from '../../stores/bulkYoloStore';
+import { useToastStore } from '../../stores/toastStore';
+import { dispatchNextBulkYolo } from '../bulkYoloDispatch';
+import type { TikiState } from '../tikiStateSync';
+import type { WorkContext } from '../../components/work';
+
+// dispatchNextBulkYolo writes to a terminal / invokes Tauri — mock it so the
+// cascade logic can be tested in isolation.
+vi.mock('../bulkYoloDispatch', () => ({ dispatchNextBulkYolo: vi.fn() }));
+const mockDispatch = vi.mocked(dispatchNextBulkYolo);
+
+const issueCtx = (number: number, status: WorkContext['status']): WorkContext => ({
+  type: 'issue',
+  issue: { number },
+  status,
+  createdAt: '2026-01-01T00:00:00Z',
+});
+
+const state = (
+  activeWork: Record<string, WorkContext>,
+  recentIssues: Array<{ number: number; completedAt: string }> = [],
+): TikiState => ({
+  schemaVersion: 1,
+  activeWork,
+  history: { recentIssues },
+});
+
+describe('advanceBulkYoloOnStateChange (#234)', () => {
+  beforeEach(() => {
+    useBulkYoloStore.setState({ runByProject: {} });
+    mockDispatch.mockClear();
+  });
+
+  it('advances the queue and dispatches the next when the current issue ships', () => {
+    useBulkYoloStore.getState().startRun([42, 43], 'term-1');
+    const prev = state({ 'issue:42': issueCtx(42, 'executing') });
+    const next = state({}, [{ number: 42, completedAt: '2026-01-01T01:00:00Z' }]);
+
+    advanceBulkYoloOnStateChange(prev, next);
+
+    const run = useBulkYoloStore.getState().runByProject['default'];
+    expect(run?.currentIndex).toBe(1);
+    expect(run?.status).toBe('running'); // 43 still queued
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith('default');
+  });
+
+  it('records a failure and does NOT dispatch when the current issue fails', () => {
+    useBulkYoloStore.getState().startRun([42, 43], 'term-1');
+    const addToast = vi.spyOn(useToastStore.getState(), 'addToast');
+    const prev = state({ 'issue:42': issueCtx(42, 'executing') });
+    const next = state({ 'issue:42': issueCtx(42, 'failed') });
+
+    advanceBulkYoloOnStateChange(prev, next);
+
+    const run = useBulkYoloStore.getState().runByProject['default'];
+    expect(run?.status).toBe('failed');
+    expect(run?.failures.at(-1)?.issueNumber).toBe(42);
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledWith(expect.stringContaining('#42 failed'), 'error');
+  });
+
+  it('is a no-op when there is no running cascade', () => {
+    const prev = state({ 'issue:42': issueCtx(42, 'executing') });
+    const next = state({}, [{ number: 42, completedAt: '2026-01-01T01:00:00Z' }]);
+
+    advanceBulkYoloOnStateChange(prev, next);
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(useBulkYoloStore.getState().runByProject['default']).toBeUndefined();
+  });
+
+  it('does not advance when a different (non-current) issue moves to history', () => {
+    useBulkYoloStore.getState().startRun([42, 43], 'term-1'); // current = 42
+    const prev = state({ 'issue:42': issueCtx(42, 'executing') });
+    // Issue 99 (not in the queue) shipped — current issue 42 is untouched.
+    const next = state(
+      { 'issue:42': issueCtx(42, 'executing') },
+      [{ number: 99, completedAt: '2026-01-01T01:00:00Z' }],
+    );
+
+    advanceBulkYoloOnStateChange(prev, next);
+
+    expect(useBulkYoloStore.getState().runByProject['default']?.currentIndex).toBe(0);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/utils/__tests__/freshRefGuard.test.ts
+++ b/apps/desktop/src/utils/__tests__/freshRefGuard.test.ts
@@ -36,6 +36,10 @@ const GUARDED_FILES = [
   'stores/kanbanStore.ts',
   'components/kanban/KanbanBoard.tsx',
   'components/detail/IssueDetail.tsx',
+  // Hooks extracted from App.tsx (#234) — they carry useEffect dep arrays in
+  // the #210/#212 crash-sensitive path, so guard them too.
+  'hooks/useTikiFileSync.ts',
+  'hooks/useGithubFreshness.ts',
 ];
 
 /** Matches `?? []`, `?? {}`, `|| []`, `|| {}` (the fresh-allocation fallbacks). */

--- a/apps/desktop/src/utils/bulkYoloCascade.ts
+++ b/apps/desktop/src/utils/bulkYoloCascade.ts
@@ -1,0 +1,41 @@
+// Bulk-YOLO cascade advance/pause logic (#234), extracted from App.tsx's
+// file-change handler into a pure, unit-testable function.
+//
+// When state.json transitions the run's current issue from activeWork into
+// history, advance the queue and dispatch the next /tiki:yolo. If the current
+// issue's status flips to 'failed', pause the run and toast. Reads/writes the
+// Zustand stores via getState() so it is callable from any context (no React).
+
+import { useProjectsStore, useBulkYoloStore, useToastStore } from "../stores";
+import { dispatchNextBulkYolo } from "./bulkYoloDispatch";
+import type { TikiState } from "./tikiStateSync";
+
+export function advanceBulkYoloOnStateChange(prev: TikiState, currentState: TikiState): void {
+  const projectId = useProjectsStore.getState().activeProjectId ?? 'default';
+  const bulkRun = useBulkYoloStore.getState().runByProject[projectId] ?? null;
+  if (!bulkRun || bulkRun.status !== 'running') return;
+
+  const currentIssue = bulkRun.queue[bulkRun.currentIndex];
+  if (currentIssue === undefined) return;
+
+  const wasActive = `issue:${currentIssue}` in (prev.activeWork ?? {});
+  const nowDone = (currentState.history?.recentIssues ?? []).some(
+    (i) => i.number === currentIssue,
+  );
+  const nowFailed =
+    currentState.activeWork?.[`issue:${currentIssue}`]?.status === 'failed';
+
+  if (wasActive && nowDone) {
+    // Issue shipped — advance the queue and dispatch the next.
+    useBulkYoloStore.getState().advance();
+    void dispatchNextBulkYolo(projectId);
+  } else if (nowFailed) {
+    useBulkYoloStore
+      .getState()
+      .recordFailure(`Issue #${currentIssue} pipeline failed`);
+    useToastStore.getState().addToast(
+      `Bulk YOLO paused: issue #${currentIssue} failed. Fix and resume from the dialog.`,
+      'error',
+    );
+  }
+}

--- a/apps/desktop/src/utils/scheduleRefresh.ts
+++ b/apps/desktop/src/utils/scheduleRefresh.ts
@@ -1,0 +1,24 @@
+// Per-surface trailing-edge debounce for GitHub re-fetches triggered by
+// state.json transitions. The watcher already coalesces filesystem-level
+// events, but logical events (e.g. shipping a 5-issue release writes
+// state.json many times in quick succession) still produce N triggers per
+// surface. 500ms trailing-edge collapses that to one fetch per surface.
+//
+// Extracted from App.tsx (#234) so both useGithubFreshness and useTikiFileSync
+// share one debounce map.
+export type RefreshSurface = 'issues' | 'prs' | 'releases';
+
+const pendingRefreshTriggers: Map<RefreshSurface, ReturnType<typeof setTimeout>> = new Map();
+const REFRESH_DEBOUNCE_MS = 500;
+
+export function scheduleRefresh(surface: RefreshSurface, fire: () => void): void {
+  const existing = pendingRefreshTriggers.get(surface);
+  if (existing) clearTimeout(existing);
+  pendingRefreshTriggers.set(
+    surface,
+    setTimeout(() => {
+      pendingRefreshTriggers.delete(surface);
+      fire();
+    }, REFRESH_DEBOUNCE_MS),
+  );
+}

--- a/apps/desktop/src/utils/tikiStateSync.ts
+++ b/apps/desktop/src/utils/tikiStateSync.ts
@@ -1,0 +1,101 @@
+// Tiki state shape + sync helpers shared between App.tsx's loadState and the
+// useTikiFileSync hook (#234). Previously these lived inline in App.tsx.
+
+import { useTikiStateStore, useToastStore, type CompletedRelease } from "../stores";
+import type { WorkContext } from "../components/work";
+
+// Types matching the Rust state structures (state.json).
+export interface TikiState {
+  schemaVersion: number;
+  activeWork: Record<string, WorkContext>;
+  history?: {
+    lastCompletedIssue?: { number: number; title?: string; completedAt: string };
+    lastCompletedRelease?: { version: string; completedAt: string };
+    recentIssues?: Array<{ number: number; title?: string; completedAt: string }>;
+    recentReleases?: Array<{ version: string; issues?: number[]; completedAt: string; tag?: string }>;
+  };
+}
+
+// Stable empty-fallback constants. Prevent fresh-object allocations in hook
+// arguments that would otherwise trigger infinite re-render loops via useEffect
+// dep instability (same bug class as #210 — see #212).
+export const EMPTY_RECENT_ISSUES: Array<{ number: number; title?: string; completedAt: string }> = [];
+const EMPTY_RECENT_RELEASES: CompletedRelease[] = [];
+
+// Normalize raw history.recentReleases (where `issues` may be absent) into the
+// store's CompletedRelease shape (`issues: number[]`). Returns the stable
+// EMPTY_RECENT_RELEASES const when there is nothing, so consumers never see a
+// fresh empty-array ref (same fresh-ref bug class as #210/#212).
+export function normalizeRecentReleases(
+  raw: Array<{ version: string; issues?: number[]; completedAt: string; tag?: string }> | undefined,
+): CompletedRelease[] {
+  if (!raw || raw.length === 0) return EMPTY_RECENT_RELEASES;
+  return raw.map((r) => ({
+    version: r.version,
+    issues: r.issues ?? [],
+    completedAt: r.completedAt,
+    ...(r.tag !== undefined ? { tag: r.tag } : {}),
+  }));
+}
+
+// Push parsed state.json into tikiStateStore (the single source for Kanban /
+// sidebar / detail). Collapses the 3 identical inline blocks that previously
+// lived in App.tsx (loadState x2 + the file-change handler).
+export function syncTikiStateStore(currentState: TikiState | null): void {
+  if (currentState?.activeWork) {
+    useTikiStateStore.getState().setActiveWork(currentState.activeWork);
+  }
+  useTikiStateStore.getState().setRecentIssues(currentState?.history?.recentIssues ?? EMPTY_RECENT_ISSUES);
+  useTikiStateStore.getState().setRecentReleases(normalizeRecentReleases(currentState?.history?.recentReleases));
+}
+
+// Compare the previous and next state and emit toasts for the user-visible
+// transitions (status changes, phase completion, audit pass, ship).
+export function detectStateChanges(
+  oldState: TikiState | null,
+  newState: TikiState | null,
+): void {
+  if (!oldState || !newState) return;
+  const addToast = useToastStore.getState().addToast;
+  const oldWork = oldState.activeWork;
+  const newWork = newState.activeWork;
+
+  for (const [workId, newItem] of Object.entries(newWork)) {
+    const oldItem = oldWork[workId];
+    if (!oldItem) continue;
+
+    // Detect status changes
+    if (oldItem.status !== newItem.status) {
+      if (newItem.status === 'completed' && newItem.type === 'issue') {
+        addToast(`Issue #${newItem.issue.number} completed`, 'success', 5000);
+      } else if (newItem.status === 'failed' && newItem.type === 'issue') {
+        addToast(`Issue #${newItem.issue.number} failed`, 'error', 8000);
+      } else if (newItem.status === 'shipping' && newItem.type === 'issue') {
+        addToast(`Shipping issue #${newItem.issue.number}...`, 'info', 3000);
+      }
+    }
+
+    // Detect phase completion for issues
+    if (newItem.type === 'issue' && oldItem.type === 'issue') {
+      const oldPhase = oldItem.phase;
+      const newPhase = newItem.phase;
+      if (oldPhase && newPhase && oldPhase.current !== newPhase.current && newPhase.current > oldPhase.current) {
+        addToast(`Phase ${newPhase.current}/${newPhase.total} completed`, 'success', 4000);
+      }
+    }
+
+    // Detect pipeline step transitions
+    if (oldItem.pipelineStep !== newItem.pipelineStep) {
+      if (oldItem.pipelineStep === 'AUDIT' && newItem.pipelineStep === 'EXECUTE') {
+        addToast('Audit passed', 'success', 3000);
+      }
+    }
+  }
+
+  // Detect work removed from activeWork (completed and moved to history)
+  for (const [workId, oldItem] of Object.entries(oldWork)) {
+    if (!newWork[workId] && oldItem.type === 'issue') {
+      addToast(`Issue #${oldItem.issue.number} shipped`, 'success', 5000);
+    }
+  }
+}


### PR DESCRIPTION
Decomposes the 722-line `App.tsx` god-component into custom hooks — the highest-reliability item in the refactor backlog, since this file is the epicenter of the #210/#212/#220 fresh-ref crash class.

## Why
App.tsx mixed five concerns inline (9 `useState`, 9 `useEffect`, 14 stores). The bulk-YOLO cascade was buried inside the watcher's `listen` callback, so it had **zero tests**. Extracting each concern isolates its `useEffect` dependency array (the actual fix for the crash class) and makes the cascade testable.

## Changes
- **`hooks/useTikiFileSync`** — the Rust watcher → state reload + transition toasts + per-surface GitHub refresh triggers + `tikiStateStore` sync.
- **`hooks/useGithubFreshness`** — focus/visibility refresh + optional rate-limit-gated poll (#221 behavior).
- **`hooks/useBulkYoloCascade`** — a stable callback wrapping the pure cascade.
- **`utils/bulkYoloCascade.ts`** → `advanceBulkYoloOnStateChange(prev, next)` — the cascade logic as a **pure, unit-tested function** (4 cases: advance-on-ship, pause-on-fail, no-op-when-idle, ignore-non-current-issue). This was previously untestable.
- **`utils/tikiStateSync.ts`** — `TikiState` type, `detectStateChanges`, `normalizeRecentReleases`, and `syncTikiStateStore` (collapses the **3 duplicated** inline sync blocks: both `loadState` branches + the file handler).
- **`utils/scheduleRefresh.ts`** — shared per-surface debounce used by both hooks.
- **`freshRefGuard`** now guards `useTikiFileSync` + `useGithubFreshness`.

## Behavior preserved
Every extracted callback/ref is stable (`bumpDetailRefresh` via `useCallback`, the cascade via `useBulkYoloCascade`, `setState`/`prevStateRef` from React), so the effects re-subscribe only on `activeProject` / settings change — identical to before. **`App.tsx` 722 → 460 lines.**

## Verification
- `pnpm build` (`tsc -b`, strict) — clean
- desktop tests **177 → 181** (+4 cascade), including `freshRefGuard` over the two new hooks
- No behavior change; pure structural extraction

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
