### PR TITLE
refactor(desktop): derive view-model types from @tiki/shared (#237)

### DIFF
--- a/apps/desktop/src/components/detail/IssueDetail.tsx
+++ b/apps/desktop/src/components/detail/IssueDetail.tsx
@@ -4,7 +4,7 @@ import type { GitHubIssue } from "../../stores";
 import { useProjectsStore, useIssuesStore, usePullRequestsStore, useDetailStore, useTerminalStore, useLayoutStore, useTikiStateStore, EMPTY_TABS } from "../../stores";
 import { resolveWorkTerminal, terminalFocusRegistry } from "../../stores/terminalStore";
 import { deriveDisplayStatus } from "../../utils/deriveDisplayStatus";
-import type { PipelineStep } from "../work/WorkCard";
+import type { PipelineStep, WorkContext } from "../work/WorkCard";
 import { IssueComments } from "./IssueComments";
 import { MarkdownRenderer } from "./MarkdownRenderer";
 import { PipelineTimeline } from "./PipelineTimeline";
@@ -16,24 +16,9 @@ import { formatDuration, calculatePhaseDuration, calculateTotalDuration } from "
 import { useElapsedTimer } from "../../hooks/useElapsedTimer";
 import "./DetailPanel.css";
 
-interface WorkContext {
-  status: string;
-  pipelineStep?: string;
-  phase?: {
-    current?: number;
-    total?: number;
-    status?: string;
-  };
-  parallelExecution?: {
-    phases: number[];
-    completedInGroup?: number[];
-    totalInGroup?: number;
-    startedAt?: string;
-  };
-  createdAt?: string;
-  lastActivity?: string;
-}
-
+// WorkContext is the shared-derived desktop view model (#237). IssueDetail only
+// reads fields common to both union members (status / pipelineStep / phase /
+// parallelExecution / createdAt / lastActivity), so no narrowing is needed.
 interface PlanPhase {
   number: number;
   title: string;

--- a/apps/desktop/src/components/work/WorkCard.tsx
+++ b/apps/desktop/src/components/work/WorkCard.tsx
@@ -1,74 +1,47 @@
-// Canonical status/pipeline unions live in @tiki/shared. Import them for local use AND
-// re-export so the existing `import ... from "../work/WorkCard"` sites keep working,
-// while @tiki/shared remains the single source of truth. Type-only → erased at build
-// (no runtime import). Fixes prior PhaseStatus drift: the local copy was missing
-// "skipped" and carried a non-canonical "running".
-import type { WorkStatus, PhaseStatus, PipelineStep } from "@tiki/shared";
-export type { WorkStatus, PhaseStatus, PipelineStep };
+// The desktop consumes a TRIMMED/augmented shape of the canonical @tiki/shared
+// work types (a smaller `issue`, an optional `lastActivity`, and a UI-only
+// `auditPassed`). Rather than re-declaring them — which drifted before (#231) —
+// these view models are DERIVED from shared via Pick/Omit, so a field rename or
+// type change in shared becomes a compile error here (#237). Type-only imports
+// → erased at build (no @tiki/shared at runtime).
+import type {
+  WorkStatus,
+  PhaseStatus,
+  PipelineStep,
+  PipelineStepRecord,
+  IssueWork,
+  ReleaseWork,
+  IssueInfo,
+  PhaseProgress,
+  ParallelExecution,
+  ReleaseInfo,
+} from "@tiki/shared";
 
-export interface PhaseInfo {
-  total: number;
-  current: number;
-  status: PhaseStatus;
-}
+// Re-export the canonical primitives/records so existing
+// `import ... from "../work/WorkCard"` sites keep resolving.
+export type { WorkStatus, PhaseStatus, PipelineStep, PipelineStepRecord, ReleaseInfo };
+
+/** Phase progress — alias of the shared canonical shape. */
+export type PhaseInfo = PhaseProgress;
+/** Parallel-execution group tracking — alias of the shared canonical shape. */
+export type ParallelExecutionInfo = ParallelExecution;
 
 /**
- * Parallel execution tracking — present only when multiple phases are running concurrently.
- * When set, sub-agents are dispatched for each phase in `phases`; once all return, the
- * parent clears this field and advances to the next group.
+ * Desktop view model: the shared IssueWork with a trimmed `issue` (the sidebar
+ * only needs number/title/url), an optional `lastActivity`, and the UI-only
+ * `auditPassed` flag. Everything else (status, pipelineStep, phase,
+ * parallelExecution, parentRelease, …) tracks shared automatically.
  */
-export interface ParallelExecutionInfo {
-  /** Phase numbers currently running in parallel */
-  phases: number[];
-  /** Phase numbers in this group that have already completed */
-  completedInGroup: number[];
-  /** Total phases in this parallel group (for progress display) */
-  totalInGroup: number;
-  /** ISO timestamp when the group started */
-  startedAt: string;
-}
-
-export interface PipelineStepRecord {
-  step: PipelineStep;
-  startedAt: string;
-  completedAt?: string;
-}
-
-export interface IssueContext {
-  type: "issue";
-  issue: {
-    number: number;
-    title?: string;
-    url?: string;
-  };
-  status: WorkStatus;
-  pipelineStep?: PipelineStep;
-  pipelineHistory?: PipelineStepRecord[];
-  phase?: PhaseInfo;
-  /** Set only while a multi-phase parallel group is in flight; cleared when group completes */
-  parallelExecution?: ParallelExecutionInfo;
-  createdAt: string;
+export type IssueContext = Omit<IssueWork, "issue" | "lastActivity"> & {
+  issue: Pick<IssueInfo, "number" | "title" | "url">;
   lastActivity?: string;
   auditPassed?: boolean;
-  parentRelease?: string;
-}
+};
 
-export interface ReleaseInfo {
-  version: string;
-  issues: number[];
-  currentIssue?: number;
-  completedIssues?: number[];
-  milestone?: string;
-}
-
-export interface ReleaseContext {
-  type: "release";
-  release: ReleaseInfo;
-  status: WorkStatus;
-  pipelineStep?: PipelineStep;
-  createdAt: string;
+/** Desktop view model: the shared ReleaseWork with an optional `lastActivity`. */
+export type ReleaseContext = Omit<ReleaseWork, "lastActivity"> & {
   lastActivity?: string;
-}
+};
 
 export type WorkContext = IssueContext | ReleaseContext;
 

--- a/apps/desktop/src/utils/tikiStateSync.ts
+++ b/apps/desktop/src/utils/tikiStateSync.ts
@@ -4,7 +4,14 @@
 import { useTikiStateStore, useToastStore, type CompletedRelease } from "../stores";
 import type { WorkContext } from "../components/work";
 
-// Types matching the Rust state structures (state.json).
+// Desktop view of state.json. The anti-drift win lives in `activeWork`: it holds
+// the shared-derived WorkContext view models (#237 — IssueContext/ReleaseContext
+// derive from @tiki/shared's IssueWork/ReleaseWork via Pick/Omit). The history
+// records stay an inline object literal on purpose: detectGithubRefreshTriggers
+// consumes `history.recentIssues` via an implicit index signature, which an
+// inline literal satisfies but a NAMED shared interface (CompletedIssueRecord)
+// does not — and `tsc -b` (project-reference build) enforces that where
+// `tsc --noEmit` does not. Keeping history inline avoids that mismatch.
 export interface TikiState {
   schemaVersion: number;
   activeWork: Record<string, WorkContext>;


### PR DESCRIPTION
Follow-up to #231 — implements the **derive** approach recommended on the issue. #231 fixed the hand-redeclared primitive unions; this derives the work view-model *interfaces* from `@tiki/shared` so they track shared (a rename/shape change there becomes a compile error here) while preserving the desktop's intentional trimming + `auditPassed` extension.

## Changes
- **`WorkCard.tsx`**
  - `IssueContext = Omit<IssueWork, "issue" | "lastActivity"> & { issue: Pick<IssueInfo, "number"|"title"|"url">; lastActivity?: string; auditPassed?: boolean }`
  - `ReleaseContext = Omit<ReleaseWork, "lastActivity"> & { lastActivity?: string }`
  - `PhaseInfo`/`ParallelExecutionInfo` → aliases of `PhaseProgress`/`ParallelExecution`; `PipelineStepRecord`/`ReleaseInfo` re-exported from shared. The hand-rolled local copies are deleted (−~50 lines).
- **`IssueDetail.tsx`** — imports `WorkContext` from WorkCard instead of a local loose redeclaration.
- **`tikiStateSync.ts`** — `activeWork` carries the derive via `WorkContext`; `history` stays an inline literal **on purpose** (documented inline).

## The `tsc -b` gotcha (why history stays inline)
Deriving `history` from shared `WorkHistory` compiled under `tsc --noEmit` but **failed under `tsc -b`**: `detectGithubRefreshTriggers` accepts a loose param whose `history.recentIssues` has an *index signature*, which an inline object-type-literal satisfies implicitly but a **named** shared interface (`CompletedIssueRecord`) does not. The project-reference build (`tsc -b`, the CLAUDE.md-documented stricter gate) enforces it. Keeping history inline avoids the mismatch; the anti-drift value is in `activeWork`/`WorkContext` regardless.

## Out of scope
The loose plan-editor view types in `IssueDetail` (`PlanPhase`/`PlanSuccessCriterion`/`TikiPlan`) are intentionally permissive ducktypes (`status: string`, nullable fields), not strict shared redeclarations — left as-is.

## Verification
- `pnpm build` (`tsc -b`, strict) — clean
- desktop tests **181** pass

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)
