### PR TITLE
fix(tracking): enforced pipeline tracking — reconcile from artifacts (#244)

### DIFF
--- a/.claude/commands/tiki/audit.md
+++ b/.claude/commands/tiki/audit.md
@@ -2,7 +2,7 @@
 name: audit
 description: Validate a plan before execution
 argument: <issue-number>
-tools: Read, Glob, Grep, AskUserQuestion
+tools: Bash, Read, Glob, Grep, AskUserQuestion
 ---
 
 # Audit Plan
@@ -137,12 +137,15 @@ If any phase has no `dependencies` field, treat it as an empty list (no deps).
 </output>
 
 <state-management>
-Set `pipelineStep: "AUDIT"`. PASS → `status: "executing"`; WARN/FAIL → keep `planning`.
+**REQUIRED — run the matching transition as the first thing after you reach a verdict, unconditionally** (regardless of how this command was invoked). Set `pipelineStep: "AUDIT"`. PASS → `status: "executing"`; WARN/FAIL → keep `planning`. Re-running is a safe no-op.
+
+**On PASS, ALSO write the AUDIT artifact to the plan file** (before or after the transition). AUDIT produces no other durable on-disk signal — `coverageMatrix` is written by PLAN — so without this, the state reconciler cannot tell AUDIT from PLAN when the transition above is dropped:
 
 ```bash
-# PASS:
+# PASS — record the verdict AND the durable artifact:
+node packages/framework/scripts/mark-audited.mjs {number}
 node packages/framework/scripts/state.mjs transition issue:{number} --to-status executing --to-step AUDIT
-# WARN or FAIL:
+# WARN or FAIL — do NOT mark audited; keep planning:
 node packages/framework/scripts/state.mjs transition issue:{number} --to-status planning --to-step AUDIT
 ```
 </state-management>

--- a/.claude/commands/tiki/execute.md
+++ b/.claude/commands/tiki/execute.md
@@ -50,6 +50,8 @@ Procedure:
 <state-update-requirement>
 ## CRITICAL: Phase State Updates
 
+Run the transition below BEFORE **every** phase — not just the first. This loop is the single most common place the desktop pipeline freezes: when you are deep in a multi-phase run dispatching sub-agents, it is easy to skip the per-phase emit and the kanban stalls on an early phase while work continues. Emit it for phase 1, phase 2, … phase T, unconditionally. Re-running with the same values is a safe no-op.
+
 Update `.tiki/state.json` BEFORE each phase. On failure, set `phase.status: "failed"` and do NOT advance `current`. When all phases finish, transition to `shipping`. (Canonical shape: see `yolo.md`.)
 
 ```bash

--- a/.claude/commands/tiki/get.md
+++ b/.claude/commands/tiki/get.md
@@ -23,7 +23,7 @@ Fetch a GitHub issue and display it in a readable format. This is typically the 
 </instructions>
 
 <state-management>
-Create the `issue:{number}` entry with `status: "pending"`, `pipelineStep: "GET"`. Canonical shape and parent-release detection: see `yolo.md` `<state-management>`.
+**REQUIRED — run this immediately after fetching the issue (you now have the title), before displaying anything.** This creates the `issue:{number}` entry the desktop app tracks; skip it and the issue never appears in the pipeline. Re-running is a safe no-op. Canonical shape and parent-release detection: see `yolo.md` `<state-management>`.
 
 ```bash
 node packages/framework/scripts/state.mjs transition issue:{number} \

--- a/.claude/commands/tiki/plan.md
+++ b/.claude/commands/tiki/plan.md
@@ -161,7 +161,7 @@ Rules:
 </research-capture>
 
 <early-state-update>
-Before planning, set the `issue:{number}` entry to `status: "planning"`, `pipelineStep: "PLAN"` (shim; see `yolo.md` for the legacy direct-write shape):
+**REQUIRED — run this FIRST, before designing any phases.** Set the `issue:{number}` entry to `status: "planning"`, `pipelineStep: "PLAN"` so the desktop pipeline advances to PLAN immediately. Emit it unconditionally as the first action regardless of how this command was invoked; it is a safe no-op if already recorded (shim; see `yolo.md` for the legacy direct-write shape):
 
 ```bash
 node packages/framework/scripts/state.mjs transition issue:{number} \

--- a/.claude/commands/tiki/review.md
+++ b/.claude/commands/tiki/review.md
@@ -137,7 +137,7 @@ Rules:
 </research-capture>
 
 <state-management>
-Record the `pending → reviewing` transition through the validated shim. The shim creates the `issue:{number}` entry if missing, updates status/`pipelineStep`/`lastActivity`, and preserves `parentRelease` automatically.
+**REQUIRED — run this FIRST, before analyzing the issue.** Record the `pending → reviewing` transition through the validated shim so the desktop pipeline advances to REVIEW immediately. Do NOT defer it to the end of the step or make it conditional on how this command was invoked — emit it unconditionally as the first action. The shim creates the `issue:{number}` entry if missing, updates status/`pipelineStep`/`lastActivity`, preserves `parentRelease`, and is a safe no-op if the step was already recorded.
 
 ```bash
 node packages/framework/scripts/state.mjs transition issue:{number} \

--- a/.claude/commands/tiki/ship.md
+++ b/.claude/commands/tiki/ship.md
@@ -241,7 +241,7 @@ All success criteria verified:
 </output>
 
 <state-management>
-Shipping is two state-machine steps. See `yolo.md` `<state-management>` for the canonical shape and the parent-release contract.
+**REQUIRED — run the `shipping` transition FIRST, before committing/pushing**, then the completion writes after the issue is closed. Emit unconditionally regardless of how this command was invoked; re-running is a safe no-op. Shipping is two state-machine steps. See `yolo.md` `<state-management>` for the canonical shape and the parent-release contract.
 
 ```bash
 # 1. Mark shipping:

--- a/.claude/commands/tiki/yolo.md
+++ b/.claude/commands/tiki/yolo.md
@@ -77,28 +77,13 @@ Phase 2 summary → Phase 3 context
 Final summary → SHIP context
 ```
 
-## CRITICAL: Sub-agent dispatch must not drop pipeline transitions
+## CRITICAL: Always emit the per-step transition from the parent
 
-When delegating REVIEW / PLAN / EXECUTE / SHIP to a sub-agent, the kanban board in the desktop app only reflects pipeline progress if `state.mjs transition` runs for each step. There are TWO acceptable patterns. **Pick one per dispatch; do not skip both.**
+The kanban board only reflects pipeline progress if `state.mjs transition` runs for each step. **Do NOT make emission conditional on how you dispatch the step** — that branch ("the skill will emit it, so I won't") is exactly how transitions get dropped and the board freezes.
 
-### Pattern A (recommended): invoke via Skill
+**The rule, with no exceptions:** BEFORE dispatching each step — whether via `Skill(...)`, a raw `Agent` / `Task`, or by doing the work inline — run the matching per-step shim block from `<state-management>` below from the parent context.
 
-Use the `Skill` tool with the matching tiki skill. The skill's own prompt body carries the `state.mjs transition` call automatically — you do not have to emit it from the parent.
-
-```
-Skill('tiki:review', '{number}')
-Skill('tiki:plan',   '{number}')
-Skill('tiki:execute','{number}')
-Skill('tiki:ship',   '{number}')
-```
-
-This is the preferred path because the transition stays co-located with the step that owns it. Use this whenever the skill exists.
-
-### Pattern B: emit the shim call from the parent
-
-If you dispatch via a raw `Agent` / `Task` (general-purpose) with a hand-crafted prompt — i.e. NOT via `Skill(...)` — the sub-agent's prompt will NOT contain the per-step transition. The parent MUST then emit the corresponding `node packages/framework/scripts/state.mjs transition` call BEFORE the dispatch (to mark the step as in-flight) and again AFTER the sub-agent returns (to mark completion / advance). Skip either call and the kanban board freezes on the prior step.
-
-See `<state-management>` below for the exact per-step shim invocations to run.
+Re-emitting a transition that a skill ALSO emits is a safe no-op: same-status transitions are always legal (`state.mjs` validates and idempotently rewrites). So "the parent emitted it and the skill emitted it again" is harmless; "neither emitted it" freezes the board. When in doubt, emit.
 </sub-agent-strategy>
 
 <output>
@@ -202,7 +187,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
   --to-status shipping --to-step SHIP
 ```
 
-If you delegated the step to a sub-agent via `Skill(...)` (Pattern A in `<sub-agent-strategy>`), the skill's own prose emits the transition and you do NOT need to emit it again from the parent. If you dispatched via raw `Agent` / `Task`, the parent MUST emit the shim call here.
+Run the matching block above before dispatching each step, **regardless of how you dispatch it** (Skill, raw Agent/Task, or inline). Double-emission is a safe no-op (same-status transitions are legal); omission freezes the kanban on the prior step. Never skip the parent emit on the assumption that something downstream will do it.
 
 ### Legacy: direct JSON
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "enabledPlugins": {
+    "understand-anything@understand-anything": true
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node packages/framework/scripts/reconcile-state.mjs --quiet"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node packages/framework/scripts/reconcile-state.mjs --quiet"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -518,6 +518,12 @@ pub struct TikiPlan {
     pub phases: Vec<Phase>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coverage_matrix: Option<HashMap<String, Vec<u32>>>,
+    /// True once AUDIT passed. The on-disk artifact the state reconciler uses to
+    /// distinguish AUDIT from PLAN (audit emits no other durable signal).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audited: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audited_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -200,7 +200,7 @@ function App() {
   // bumpDetailRefresh are stable, so these effects re-subscribe only on
   // activeProject / settings change, preserving the original behavior.
   const advanceBulkYolo = useBulkYoloCascade();
-  useTikiFileSync({ activeProject, prevStateRef, setState, bumpDetailRefresh, onStateChange: advanceBulkYolo });
+  useTikiFileSync({ activeProjectPath: activeProject?.path ?? null, prevStateRef, setState, bumpDetailRefresh, onStateChange: advanceBulkYolo });
   useGithubFreshness(bumpDetailRefresh);
 
   const handleResetLayout = () => {
@@ -399,7 +399,11 @@ function App() {
         >
           <div className="detail-content">
             {selectedIssueData ? (
-              <IssueDetail issue={selectedIssueData} work={selectedIssueWork} />
+              <IssueDetail
+                issue={selectedIssueData}
+                work={selectedIssueWork}
+                stale={staleFlags?.[`issue:${selectedIssue}`] ?? false}
+              />
             ) : selectedPrData ? (
               <PullRequestDetail pr={selectedPrData} />
             ) : selectedReleaseData ? (

--- a/apps/desktop/src/components/detail/IssueDetail.tsx
+++ b/apps/desktop/src/components/detail/IssueDetail.tsx
@@ -51,6 +51,8 @@ interface TikiPlan {
 interface IssueDetailProps {
   issue: GitHubIssue;
   work?: WorkContext | null;
+  /** True when this issue's tracked state is stale (drives the anomaly badge, #246). */
+  stale?: boolean;
 }
 
 function PhaseItem({ phase }: { phase: PlanPhase }) {
@@ -120,7 +122,7 @@ function getLinkedPrReviewLabel(decision: string): string {
   return "Review";
 }
 
-export function IssueDetail({ issue, work }: IssueDetailProps) {
+export function IssueDetail({ issue, work, stale }: IssueDetailProps) {
   const [isClosing, setIsClosing] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -237,8 +239,9 @@ export function IssueDetail({ issue, work }: IssueDetailProps) {
           : null,
         githubState: { state: issue.state.toLowerCase() === "closed" ? "closed" : "open" },
         history: { recentIssues, recentReleases },
+        stale: stale ?? false,
       }),
-    [issue.number, issue.state, work, recentIssues, recentReleases]
+    [issue.number, issue.state, work, recentIssues, recentReleases, stale]
   );
 
   const badgeClass = display.badge === "Closed" ? stateBadgeStyles.closed : stateBadgeStyles.open;

--- a/apps/desktop/src/hooks/useTikiFileSync.ts
+++ b/apps/desktop/src/hooks/useTikiFileSync.ts
@@ -28,8 +28,18 @@ interface FileEvent {
 }
 
 interface UseTikiFileSyncParams {
-  /** Active project (or null/undefined for the default cwd-based path). */
-  activeProject: { path: string } | null | undefined;
+  /**
+   * Active project PATH (or null/undefined for the default cwd-based path).
+   *
+   * Deliberately a primitive string, NOT the whole project object: the project
+   * object is reallocated on every framework-version stamp (projectsStore
+   * setProjectFrameworkVersion does `projects.map(p => ({...p}))`), which would
+   * make this effect's dep change on each stamp and tear down + re-subscribe the
+   * async `tiki-file-changed` listener — any state write landing in that gap is
+   * lost. Keying on the path string keeps the subscription stable across stamps,
+   * so it re-subscribes only on a real project switch (#249 / epic #244).
+   */
+  activeProjectPath: string | null | undefined;
   /** App's previous-state ref, updated after each reload for change detection. */
   prevStateRef: RefObject<TikiState | null>;
   /** App's state setter — the reloaded state is pushed here for rendering. */
@@ -41,7 +51,7 @@ interface UseTikiFileSyncParams {
 }
 
 export function useTikiFileSync({
-  activeProject,
+  activeProjectPath,
   prevStateRef,
   setState,
   bumpDetailRefresh,
@@ -52,7 +62,7 @@ export function useTikiFileSync({
       console.log("File changed:", event.payload);
       if (event.payload.type === "stateChanged") {
         try {
-          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
+          const projectTikiPath = activeProjectPath ? `${activeProjectPath}/.tiki` : undefined;
           const currentState = await invoke<TikiState | null>("get_state", {
             tikiPath: projectTikiPath,
           });
@@ -87,7 +97,7 @@ export function useTikiFileSync({
         }
       } else if (event.payload.type === "releaseChanged") {
         try {
-          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
+          const projectTikiPath = activeProjectPath ? `${activeProjectPath}/.tiki` : undefined;
           const loadedReleases = await invoke<TikiRelease[]>("load_tiki_releases", { tikiPath: projectTikiPath });
           useTikiReleasesStore.getState().setReleases(loadedReleases);
         } catch (e) {
@@ -95,7 +105,7 @@ export function useTikiFileSync({
         }
       } else if (event.payload.type === "researchChanged") {
         try {
-          const projectTikiPath = activeProject ? `${activeProject.path}/.tiki` : undefined;
+          const projectTikiPath = activeProjectPath ? `${activeProjectPath}/.tiki` : undefined;
           const loadedDocs = await invoke<ResearchDocMeta[]>("list_research_docs", { tikiPath: projectTikiPath });
           useResearchStore.getState().setDocs(loadedDocs);
         } catch (e) {
@@ -107,5 +117,5 @@ export function useTikiFileSync({
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, [activeProject, prevStateRef, setState, bumpDetailRefresh, onStateChange]);
+  }, [activeProjectPath, prevStateRef, setState, bumpDetailRefresh, onStateChange]);
 }

--- a/apps/desktop/src/utils/__tests__/deriveDisplayStatus.test.ts
+++ b/apps/desktop/src/utils/__tests__/deriveDisplayStatus.test.ts
@@ -52,6 +52,39 @@ describe('deriveDisplayStatus — #218 precedence table', () => {
     expect(out.anomaly).toBeTruthy();
   });
 
+  it('stale: in-flight executing + stale=true → active pipeline with a stall anomaly (#246)', () => {
+    const out = deriveDisplayStatus({
+      number: 500,
+      work: { status: 'executing', pipelineStep: 'EXECUTE' },
+      githubState: { state: 'open' },
+      stale: true,
+    });
+    expect(out.column).toBe('execute');
+    expect(out.pipelineState).toBe('active');
+    expect(out.anomaly).toMatch(/stalled/i);
+  });
+
+  it('not stale: in-flight executing + stale=false → no anomaly (#246)', () => {
+    const out = deriveDisplayStatus({
+      number: 501,
+      work: { status: 'executing', pipelineStep: 'EXECUTE' },
+      githubState: { state: 'open' },
+      stale: false,
+    });
+    expect(out.anomaly).toBeUndefined();
+  });
+
+  it('stale never overrides the higher-priority Tiki-done/GitHub-open anomaly (#246)', () => {
+    const out = deriveDisplayStatus({
+      number: 502,
+      work: { status: 'shipping', pipelineStep: 'SHIP' },
+      githubState: { state: 'open' },
+      stale: true,
+    });
+    // Row 1 wins: the anomaly is the Tiki-vs-GitHub disagreement, not the stall.
+    expect(out.anomaly).toMatch(/still open/i);
+  });
+
   it('closed-not-merged: in history + GitHub closed + merged=false → Completed, Closed badge, partial pipeline', () => {
     const out = deriveDisplayStatus({
       number: 77,

--- a/apps/desktop/src/utils/deriveDisplayStatus.ts
+++ b/apps/desktop/src/utils/deriveDisplayStatus.ts
@@ -92,6 +92,14 @@ export interface DeriveDisplayStatusInput {
   githubState?: GithubStateLike | null;
   /** history.recentIssues + history.recentReleases. */
   history?: HistoryLike | null;
+  /**
+   * True when the item is in-flight but its tracked state has not advanced for a
+   * while (computed by the caller — this function stays pure and clockless). Used
+   * to surface a stale-tracking anomaly so a silently-frozen pipeline is visible
+   * rather than appearing stuck (#246 / epic #244). Only applied to active
+   * in-flight rows; never overrides a higher-priority anomaly.
+   */
+  stale?: boolean;
 }
 
 const STATUS_TO_COLUMN: Record<string, DisplayColumn> = {
@@ -135,7 +143,7 @@ function isInHistory(num: number, history: HistoryLike | null | undefined): bool
  * exact order of the #218 precedence table.
  */
 export function deriveDisplayStatus(input: DeriveDisplayStatusInput): DisplayStatus {
-  const { number, work, githubState, history } = input;
+  const { number, work, githubState, history, stale } = input;
   const gh = githubState?.state; // 'open' | 'closed' | undefined
   const ghBadge: DisplayBadge = gh === 'closed' ? 'Closed' : 'Open';
   const tikiStatus = work?.status;
@@ -179,6 +187,10 @@ export function deriveDisplayStatus(input: DeriveDisplayStatusInput): DisplaySta
         label: STATUS_LABEL[tikiStatus] ?? tikiStatus,
         pipelineState: 'active',
         badge: ghBadge,
+        // Surface a stalled pipeline (in-flight but not advancing) so a silent
+        // freeze is visible. The reconciler (#245) prevents most freezes; this
+        // is the safety net for a genuinely stuck run (#246).
+        ...(stale ? { anomaly: 'Pipeline stalled — no tracked progress recently' } : {}),
       };
     }
     // Unknown Tiki status — fall through to the history/GitHub rows.

--- a/packages/framework/__tests__/command-transition-coverage.test.mjs
+++ b/packages/framework/__tests__/command-transition-coverage.test.mjs
@@ -96,6 +96,40 @@ test("every command file retains its expected state.mjs transition --to-step pai
   );
 });
 
+// Regression assertion for issue #247: yolo.md must NOT reintroduce the
+// conditional "the skill will emit it, so the parent won't" dispatch trap. That
+// branch (formerly "Pattern A / Pattern B") is exactly how intermediate
+// transitions get dropped and the kanban freezes mid-pipeline. The contract is
+// now unconditional: always emit the per-step transition from the parent.
+test("yolo.md does not reintroduce the conditional-emit (Pattern A/B) trap", () => {
+  const filePath = path.join(COMMANDS_DIR, "yolo.md");
+  const content = fs.readFileSync(filePath, "utf-8");
+
+  const forbidden = [
+    /Pattern A/,
+    /Pattern B/,
+    /do NOT need to emit/i,
+    /you do not have to emit/i,
+  ];
+  const offenders = forbidden.filter((re) => re.test(content)).map((re) => re.source);
+
+  assert.equal(
+    offenders.length,
+    0,
+    `yolo.md reintroduced conditional transition-emit language [${offenders.join(", ")}]. ` +
+    `Transition emission must be UNCONDITIONAL — always emit the per-step shim call from ` +
+    `the parent regardless of dispatch (Skill / Agent / Task / inline). Double-emit is a ` +
+    `safe no-op; the conditional branch is what drops transitions (issue #247).`
+  );
+
+  // And positively assert the unconditional rule is present.
+  assert.match(
+    content,
+    /unconditional|regardless of how you dispatch/i,
+    `yolo.md must state the unconditional-emit rule (issue #247).`
+  );
+});
+
 // Regression assertion for issue #219: the release teardown must append each
 // child issue to history.recentIssues (`append-history issue`). Without it, the
 // desktop Kanban "Completed" column — which reads only recentIssues — drops

--- a/packages/framework/__tests__/reconcile-state.test.mjs
+++ b/packages/framework/__tests__/reconcile-state.test.mjs
@@ -1,0 +1,237 @@
+/**
+ * Tests for reconcile-state.mjs (epic #244 / issue #245 + #248).
+ *
+ * These are RUNTIME assertions: they build fixture .tiki trees and prove the
+ * reconciler derives the correct pipeline state from artifacts — including the
+ * two traps surfaced in design review (a `failed` item whose artifacts advanced;
+ * a stale all-complete plan for a shipped issue) and the drop-resilience case
+ * (correct state with ZERO imperative transitions). This closes the gap the
+ * prose-only command-transition-coverage test could never cover (the deferred
+ * #211 "Phase 4").
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { reconcile } from "../scripts/reconcile-state.mjs";
+
+function makeTiki(state, plans = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tiki-reconcile-"));
+  const tikiPath = path.join(dir, ".tiki");
+  fs.mkdirSync(path.join(tikiPath, "plans"), { recursive: true });
+  fs.writeFileSync(path.join(tikiPath, "state.json"), JSON.stringify(state, null, 2));
+  for (const [num, plan] of Object.entries(plans)) {
+    fs.writeFileSync(
+      path.join(tikiPath, "plans", `issue-${num}.json`),
+      JSON.stringify(plan, null, 2)
+    );
+  }
+  return tikiPath;
+}
+
+function readBack(tikiPath) {
+  return JSON.parse(fs.readFileSync(path.join(tikiPath, "state.json"), "utf-8"));
+}
+
+const issueEntry = (number, over = {}) => ({
+  type: "issue",
+  issue: { number, title: `Issue ${number}` },
+  status: "pending",
+  pipelineStep: "GET",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastActivity: "2026-01-01T00:00:00.000Z",
+  ...over,
+});
+
+const plan = (number, phases, over = {}) => ({
+  schemaVersion: 1,
+  issue: { number, title: `Issue ${number}` },
+  createdAt: "2026-01-01T00:00:00.000Z",
+  phases: phases.map((status, i) => ({
+    number: i + 1,
+    title: `Phase ${i + 1}`,
+    status,
+    content: "...",
+  })),
+  ...over,
+});
+
+test("advances REVIEW → PLAN when a plan file exists", () => {
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:10": issueEntry(10, { status: "reviewing", pipelineStep: "REVIEW" }) }, history: {} },
+    { 10: plan(10, ["pending", "pending"]) }
+  );
+  reconcile(tikiPath);
+  const e = readBack(tikiPath).activeWork["issue:10"];
+  assert.equal(e.status, "planning");
+  assert.equal(e.pipelineStep, "PLAN");
+});
+
+test("advances PLAN → AUDIT only when plan.audited is true", () => {
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:11": issueEntry(11, { status: "planning", pipelineStep: "PLAN" }) }, history: {} },
+    { 11: plan(11, ["pending", "pending"], { audited: true }) }
+  );
+  reconcile(tikiPath);
+  const e = readBack(tikiPath).activeWork["issue:11"];
+  assert.equal(e.pipelineStep, "AUDIT");
+  assert.equal(e.status, "planning"); // status stays planning until a phase runs
+});
+
+test("derives EXECUTE phase progress from the plan (the freeze the user reported)", () => {
+  // Entry frozen at PLAN (its EXECUTE transitions were dropped) but the plan
+  // shows phase 1 done, phase 2 running. Reconciler must advance to EXECUTE 2/5.
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:12": issueEntry(12, { status: "planning", pipelineStep: "PLAN" }) }, history: {} },
+    { 12: plan(12, ["completed", "executing", "pending", "pending", "pending"], { audited: true }) }
+  );
+  reconcile(tikiPath);
+  const e = readBack(tikiPath).activeWork["issue:12"];
+  assert.equal(e.status, "executing");
+  assert.equal(e.pipelineStep, "EXECUTE");
+  assert.deepEqual(e.phase, { current: 2, total: 5, status: "executing" });
+});
+
+test("DROP-RESILIENCE: correct EXECUTE state with ZERO imperative transitions after GET", () => {
+  // Only the GET entry exists; every later transition was dropped. The plan
+  // shows all phases complete. The reconciler must reach EXECUTE 5/5 from
+  // artifacts alone — and must NOT fabricate SHIP/completed (no history).
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:13": issueEntry(13) }, history: {} },
+    { 13: plan(13, ["completed", "completed", "completed", "completed", "completed"], { audited: true }) }
+  );
+  reconcile(tikiPath);
+  const e = readBack(tikiPath).activeWork["issue:13"];
+  assert.equal(e.status, "executing");
+  assert.equal(e.pipelineStep, "EXECUTE");
+  assert.deepEqual(e.phase, { current: 5, total: 5, status: "completed" });
+});
+
+test("advances phase progress within EXECUTE", () => {
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:14": issueEntry(14, { status: "executing", pipelineStep: "EXECUTE", phase: { current: 1, total: 5, status: "executing" } }) }, history: {} },
+    { 14: plan(14, ["completed", "completed", "completed", "executing", "pending"], { audited: true }) }
+  );
+  reconcile(tikiPath);
+  const e = readBack(tikiPath).activeWork["issue:14"];
+  assert.equal(e.phase.current, 4);
+});
+
+test("never moves backward (advance-only)", () => {
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:15": issueEntry(15, { status: "executing", pipelineStep: "EXECUTE", phase: { current: 4, total: 5, status: "executing" } }) }, history: {} },
+    { 15: plan(15, ["completed", "pending", "pending", "pending", "pending"], { audited: true }) }
+  );
+  const before = readBack(tikiPath).activeWork["issue:15"];
+  const r = reconcile(tikiPath);
+  const after = readBack(tikiPath).activeWork["issue:15"];
+  assert.equal(after.phase.current, 4); // not pulled back to 2
+  assert.equal(r.changes.length, 0);
+  assert.equal(before.lastActivity, after.lastActivity);
+});
+
+test("TRAP: a `failed` item is never touched even when artifacts advanced", () => {
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:16": issueEntry(16, { status: "failed", pipelineStep: "EXECUTE", phase: { current: 2, total: 5, status: "failed" } }) }, history: {} },
+    { 16: plan(16, ["completed", "completed", "completed", "completed", "completed"], { audited: true }) }
+  );
+  const r = reconcile(tikiPath);
+  const e = readBack(tikiPath).activeWork["issue:16"];
+  assert.equal(e.status, "failed");
+  assert.equal(r.changes.length, 0);
+});
+
+test("TRAP: a `paused` item is never touched", () => {
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:17": issueEntry(17, { status: "paused", pipelineStep: "EXECUTE" }) }, history: {} },
+    { 17: plan(17, ["completed", "executing", "pending"], { audited: true }) }
+  );
+  const r = reconcile(tikiPath);
+  assert.equal(readBack(tikiPath).activeWork["issue:17"].status, "paused");
+  assert.equal(r.changes.length, 0);
+});
+
+test("TRAP: a stale all-complete plan for an issue NOT in activeWork is never resurrected", () => {
+  // issue:299 shipped long ago (live plan, all complete) but is not tracked.
+  // Only issue:300 is active. The reconciler must not recreate 299.
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:300": issueEntry(300, { status: "reviewing", pipelineStep: "REVIEW" }) }, history: {} },
+    {
+      299: plan(299, ["completed", "completed"], { audited: true }),
+      300: plan(300, ["pending"]),
+    }
+  );
+  reconcile(tikiPath);
+  const aw = readBack(tikiPath).activeWork;
+  assert.equal("issue:299" in aw, false);
+  assert.ok("issue:300" in aw);
+});
+
+test("completion: standalone issue in history is removed from activeWork", () => {
+  const tikiPath = makeTiki(
+    {
+      schemaVersion: 1,
+      activeWork: { "issue:42": issueEntry(42, { status: "executing", pipelineStep: "EXECUTE" }) },
+      history: { recentIssues: [{ number: 42, title: "Issue 42", completedAt: "2026-01-02T00:00:00.000Z" }] },
+    },
+    { 42: plan(42, ["completed"]) }
+  );
+  const r = reconcile(tikiPath);
+  assert.equal("issue:42" in readBack(tikiPath).activeWork, false);
+  assert.equal(r.changes[0].action, "removed");
+});
+
+test("completion: release child in history becomes completed and keeps parentRelease", () => {
+  const tikiPath = makeTiki(
+    {
+      schemaVersion: 1,
+      activeWork: { "issue:43": issueEntry(43, { status: "executing", pipelineStep: "EXECUTE", parentRelease: "v1.0" }) },
+      history: { recentIssues: [{ number: 43, title: "Issue 43", completedAt: "2026-01-02T00:00:00.000Z" }] },
+    },
+    { 43: plan(43, ["completed"]) }
+  );
+  reconcile(tikiPath);
+  const e = readBack(tikiPath).activeWork["issue:43"];
+  assert.equal(e.status, "completed");
+  assert.equal(e.pipelineStep, "SHIP");
+  assert.equal(e.parentRelease, "v1.0");
+});
+
+test("release:* entries are left untouched", () => {
+  const releaseEntry = {
+    type: "release",
+    release: { version: "v1.0", issues: [50], completedIssues: [] },
+    status: "executing",
+    pipelineStep: "EXECUTE",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    lastActivity: "2026-01-01T00:00:00.000Z",
+  };
+  const tikiPath = makeTiki({ schemaVersion: 1, activeWork: { "release:v1.0": releaseEntry }, history: {} });
+  const r = reconcile(tikiPath);
+  assert.equal(r.changes.length, 0);
+  assert.deepEqual(readBack(tikiPath).activeWork["release:v1.0"], releaseEntry);
+});
+
+test("no plan file → pre-PLAN entry is left alone (covered by foreground #247)", () => {
+  const tikiPath = makeTiki({
+    schemaVersion: 1,
+    activeWork: { "issue:18": issueEntry(18, { status: "reviewing", pipelineStep: "REVIEW" }) },
+    history: {},
+  });
+  const r = reconcile(tikiPath);
+  assert.equal(r.changes.length, 0);
+  assert.equal(readBack(tikiPath).activeWork["issue:18"].pipelineStep, "REVIEW");
+});
+
+test("--dry-run computes changes without writing", () => {
+  const tikiPath = makeTiki(
+    { schemaVersion: 1, activeWork: { "issue:19": issueEntry(19, { status: "reviewing", pipelineStep: "REVIEW" }) }, history: {} },
+    { 19: plan(19, ["pending"]) }
+  );
+  const r = reconcile(tikiPath, { dryRun: true });
+  assert.equal(r.changes.length, 1);
+  // Disk unchanged.
+  assert.equal(readBack(tikiPath).activeWork["issue:19"].pipelineStep, "REVIEW");
+});

--- a/packages/framework/commands/audit.md
+++ b/packages/framework/commands/audit.md
@@ -2,7 +2,7 @@
 name: audit
 description: Validate a plan before execution
 argument: <issue-number>
-tools: Read, Glob, Grep, AskUserQuestion
+tools: Bash, Read, Glob, Grep, AskUserQuestion
 ---
 
 # Audit Plan
@@ -137,12 +137,15 @@ If any phase has no `dependencies` field, treat it as an empty list (no deps).
 </output>
 
 <state-management>
-Set `pipelineStep: "AUDIT"`. PASS → `status: "executing"`; WARN/FAIL → keep `planning`.
+**REQUIRED — run the matching transition as the first thing after you reach a verdict, unconditionally** (regardless of how this command was invoked). Set `pipelineStep: "AUDIT"`. PASS → `status: "executing"`; WARN/FAIL → keep `planning`. Re-running is a safe no-op.
+
+**On PASS, ALSO write the AUDIT artifact to the plan file** (before or after the transition). AUDIT produces no other durable on-disk signal — `coverageMatrix` is written by PLAN — so without this, the state reconciler cannot tell AUDIT from PLAN when the transition above is dropped:
 
 ```bash
-# PASS:
+# PASS — record the verdict AND the durable artifact:
+node packages/framework/scripts/mark-audited.mjs {number}
 node packages/framework/scripts/state.mjs transition issue:{number} --to-status executing --to-step AUDIT
-# WARN or FAIL:
+# WARN or FAIL — do NOT mark audited; keep planning:
 node packages/framework/scripts/state.mjs transition issue:{number} --to-status planning --to-step AUDIT
 ```
 </state-management>

--- a/packages/framework/commands/execute.md
+++ b/packages/framework/commands/execute.md
@@ -50,6 +50,8 @@ Procedure:
 <state-update-requirement>
 ## CRITICAL: Phase State Updates
 
+Run the transition below BEFORE **every** phase — not just the first. This loop is the single most common place the desktop pipeline freezes: when you are deep in a multi-phase run dispatching sub-agents, it is easy to skip the per-phase emit and the kanban stalls on an early phase while work continues. Emit it for phase 1, phase 2, … phase T, unconditionally. Re-running with the same values is a safe no-op.
+
 Update `.tiki/state.json` BEFORE each phase. On failure, set `phase.status: "failed"` and do NOT advance `current`. When all phases finish, transition to `shipping`. (Canonical shape: see `yolo.md`.)
 
 ```bash

--- a/packages/framework/commands/get.md
+++ b/packages/framework/commands/get.md
@@ -23,7 +23,7 @@ Fetch a GitHub issue and display it in a readable format. This is typically the 
 </instructions>
 
 <state-management>
-Create the `issue:{number}` entry with `status: "pending"`, `pipelineStep: "GET"`. Canonical shape and parent-release detection: see `yolo.md` `<state-management>`.
+**REQUIRED — run this immediately after fetching the issue (you now have the title), before displaying anything.** This creates the `issue:{number}` entry the desktop app tracks; skip it and the issue never appears in the pipeline. Re-running is a safe no-op. Canonical shape and parent-release detection: see `yolo.md` `<state-management>`.
 
 ```bash
 node packages/framework/scripts/state.mjs transition issue:{number} \

--- a/packages/framework/commands/plan.md
+++ b/packages/framework/commands/plan.md
@@ -161,7 +161,7 @@ Rules:
 </research-capture>
 
 <early-state-update>
-Before planning, set the `issue:{number}` entry to `status: "planning"`, `pipelineStep: "PLAN"` (shim; see `yolo.md` for the legacy direct-write shape):
+**REQUIRED — run this FIRST, before designing any phases.** Set the `issue:{number}` entry to `status: "planning"`, `pipelineStep: "PLAN"` so the desktop pipeline advances to PLAN immediately. Emit it unconditionally as the first action regardless of how this command was invoked; it is a safe no-op if already recorded (shim; see `yolo.md` for the legacy direct-write shape):
 
 ```bash
 node packages/framework/scripts/state.mjs transition issue:{number} \

--- a/packages/framework/commands/review.md
+++ b/packages/framework/commands/review.md
@@ -137,7 +137,7 @@ Rules:
 </research-capture>
 
 <state-management>
-Record the `pending → reviewing` transition through the validated shim. The shim creates the `issue:{number}` entry if missing, updates status/`pipelineStep`/`lastActivity`, and preserves `parentRelease` automatically.
+**REQUIRED — run this FIRST, before analyzing the issue.** Record the `pending → reviewing` transition through the validated shim so the desktop pipeline advances to REVIEW immediately. Do NOT defer it to the end of the step or make it conditional on how this command was invoked — emit it unconditionally as the first action. The shim creates the `issue:{number}` entry if missing, updates status/`pipelineStep`/`lastActivity`, preserves `parentRelease`, and is a safe no-op if the step was already recorded.
 
 ```bash
 node packages/framework/scripts/state.mjs transition issue:{number} \

--- a/packages/framework/commands/ship.md
+++ b/packages/framework/commands/ship.md
@@ -241,7 +241,7 @@ All success criteria verified:
 </output>
 
 <state-management>
-Shipping is two state-machine steps. See `yolo.md` `<state-management>` for the canonical shape and the parent-release contract.
+**REQUIRED — run the `shipping` transition FIRST, before committing/pushing**, then the completion writes after the issue is closed. Emit unconditionally regardless of how this command was invoked; re-running is a safe no-op. Shipping is two state-machine steps. See `yolo.md` `<state-management>` for the canonical shape and the parent-release contract.
 
 ```bash
 # 1. Mark shipping:

--- a/packages/framework/commands/yolo.md
+++ b/packages/framework/commands/yolo.md
@@ -77,28 +77,13 @@ Phase 2 summary → Phase 3 context
 Final summary → SHIP context
 ```
 
-## CRITICAL: Sub-agent dispatch must not drop pipeline transitions
+## CRITICAL: Always emit the per-step transition from the parent
 
-When delegating REVIEW / PLAN / EXECUTE / SHIP to a sub-agent, the kanban board in the desktop app only reflects pipeline progress if `state.mjs transition` runs for each step. There are TWO acceptable patterns. **Pick one per dispatch; do not skip both.**
+The kanban board only reflects pipeline progress if `state.mjs transition` runs for each step. **Do NOT make emission conditional on how you dispatch the step** — that branch ("the skill will emit it, so I won't") is exactly how transitions get dropped and the board freezes.
 
-### Pattern A (recommended): invoke via Skill
+**The rule, with no exceptions:** BEFORE dispatching each step — whether via `Skill(...)`, a raw `Agent` / `Task`, or by doing the work inline — run the matching per-step shim block from `<state-management>` below from the parent context.
 
-Use the `Skill` tool with the matching tiki skill. The skill's own prompt body carries the `state.mjs transition` call automatically — you do not have to emit it from the parent.
-
-```
-Skill('tiki:review', '{number}')
-Skill('tiki:plan',   '{number}')
-Skill('tiki:execute','{number}')
-Skill('tiki:ship',   '{number}')
-```
-
-This is the preferred path because the transition stays co-located with the step that owns it. Use this whenever the skill exists.
-
-### Pattern B: emit the shim call from the parent
-
-If you dispatch via a raw `Agent` / `Task` (general-purpose) with a hand-crafted prompt — i.e. NOT via `Skill(...)` — the sub-agent's prompt will NOT contain the per-step transition. The parent MUST then emit the corresponding `node packages/framework/scripts/state.mjs transition` call BEFORE the dispatch (to mark the step as in-flight) and again AFTER the sub-agent returns (to mark completion / advance). Skip either call and the kanban board freezes on the prior step.
-
-See `<state-management>` below for the exact per-step shim invocations to run.
+Re-emitting a transition that a skill ALSO emits is a safe no-op: same-status transitions are always legal (`state.mjs` validates and idempotently rewrites). So "the parent emitted it and the skill emitted it again" is harmless; "neither emitted it" freezes the board. When in doubt, emit.
 </sub-agent-strategy>
 
 <output>
@@ -202,7 +187,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
   --to-status shipping --to-step SHIP
 ```
 
-If you delegated the step to a sub-agent via `Skill(...)` (Pattern A in `<sub-agent-strategy>`), the skill's own prose emits the transition and you do NOT need to emit it again from the parent. If you dispatched via raw `Agent` / `Task`, the parent MUST emit the shim call here.
+Run the matching block above before dispatching each step, **regardless of how you dispatch it** (Skill, raw Agent/Task, or inline). Double-emission is a safe no-op (same-status transitions are legal); omission freezes the kanban on the prior step. Never skip the parent emit on the assumption that something downstream will do it.
 
 ### Legacy: direct JSON
 

--- a/packages/framework/scripts/mark-audited.mjs
+++ b/packages/framework/scripts/mark-audited.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Tiki AUDIT-artifact writer.
+ *
+ * AUDIT is the one pipeline step that produces no durable on-disk signal of its
+ * own: `coverageMatrix` is written by PLAN, and audit.md only READS the plan.
+ * That left the state reconciler (issue #245 / epic #244) unable to distinguish
+ * AUDIT from PLAN. This script writes the missing artifact — `audited: true` +
+ * `auditedAt` — onto `.tiki/plans/issue-<n>.json`, so the reconciler can derive
+ * the AUDIT step from disk even when the imperative state.mjs transition was
+ * dropped.
+ *
+ * Usage:
+ *   node mark-audited.mjs <issue-number> [--tiki-path <path>] [--dry-run]
+ *
+ * Run by /tiki:audit on PASS (see audit.md <state-management>). Idempotent:
+ * re-running just refreshes auditedAt. Node built-ins only (mirrors state.mjs).
+ *
+ * Exit codes: 0 success · 1 bad args / missing plan · 2 I/O error.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { resolveTikiPath } from "./state.mjs";
+
+function die(code, msg) {
+  process.stderr.write(`mark-audited.mjs: ${msg}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+    } else {
+      args._.push(a);
+    }
+  }
+  return args;
+}
+
+function writeJsonAtomic(file, obj) {
+  const tmp = file + ".tmp";
+  const json = JSON.stringify(obj, null, 2);
+  try {
+    fs.writeFileSync(tmp, json, "utf-8");
+    fs.renameSync(tmp, file);
+  } catch (e) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    die(2, `failed to write ${file}: ${e.message}`);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const raw = args._[0];
+  const number = Number(raw);
+  if (!Number.isInteger(number) || number < 1) {
+    die(1, `missing/invalid <issue-number> (got '${raw}')`);
+  }
+
+  const tikiPath = resolveTikiPath(args["tiki-path"]);
+  const planFile = path.join(tikiPath, "plans", `issue-${number}.json`);
+  if (!fs.existsSync(planFile)) {
+    die(1, `no plan file at ${planFile} — run /tiki:plan ${number} first`);
+  }
+
+  let plan;
+  try {
+    plan = JSON.parse(fs.readFileSync(planFile, "utf-8"));
+  } catch (e) {
+    die(2, `plan file is not valid JSON: ${e.message}`);
+  }
+
+  plan.audited = true;
+  plan.auditedAt = new Date().toISOString();
+
+  if (args["dry-run"] !== true) {
+    writeJsonAtomic(planFile, plan);
+  }
+
+  process.stdout.write(
+    JSON.stringify({ issue: number, audited: true, auditedAt: plan.auditedAt }, null, 2) + "\n"
+  );
+}
+
+import { fileURLToPath } from "node:url";
+const isCliEntry = (() => {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const entryFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+    return entryFile !== null && path.resolve(thisFile) === entryFile;
+  } catch {
+    return false;
+  }
+})();
+
+if (isCliEntry) {
+  main();
+}

--- a/packages/framework/scripts/reconcile-state.mjs
+++ b/packages/framework/scripts/reconcile-state.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+/**
+ * reconcile-state.mjs — derive pipeline state from on-disk artifacts.
+ *
+ * Epic #244 / issue #245. Tiki's pipeline tracking has historically been a
+ * "report" contract: each /tiki step must remember to run `state.mjs transition`
+ * before it. When the LLM forgets (common in long EXECUTE runs / sub-agent
+ * dispatch), the desktop kanban freezes mid-pipeline. This reconciler flips the
+ * write side to a "reconcile" contract: it RECOMPUTES each active issue's true
+ * pipeline step from artifacts the work physically had to produce, so a dropped
+ * transition self-heals on the next pass.
+ *
+ * It is meant to run as a Claude Code `Stop` AND `SubagentStop` hook (see
+ * .claude/settings.json) so it fires after every assistant/sub-agent turn —
+ * independent of whether the imperative transition ran.
+ *
+ * SAFETY CONTRACT (every rule here is a fix for a real trap found in design
+ * review — do not relax without re-reviewing):
+ *
+ *   1. activeWork-scoped. ONLY mutates issue entries that ALREADY exist in
+ *      state.activeWork. It never scans plan files to CREATE entries — the repo
+ *      has ~100 live plan files for long-shipped issues (plan archiving is
+ *      dropped as often as transitions), and resurrecting them would flood the
+ *      kanban. Early steps (GET→PLAN, before an entry exists) are covered by the
+ *      unconditional foreground transitions from #247, not by this reconciler.
+ *   2. Advance-only. Never moves an item backward; only forward when artifacts
+ *      justify a later step (or more phase progress) than currently recorded.
+ *   3. Skips LLM-set / terminal states. Never touches status failed | paused |
+ *      completed — those are decisions the artifacts can't override.
+ *   4. Completion comes from history, not plan phases. "All phases complete"
+ *      does NOT mean shipped (no ship/archive artifact is reliable). The
+ *      authoritative done-signal is membership in history.recentIssues.
+ *   5. Legality pre-guarded. Every advance is checked with isLegalTransition
+ *      BEFORE applyTransition, so applyTransition can never die() and crash the
+ *      hook. release:* entries and parentRelease are left untouched.
+ *   6. Never blocks. Lenient locking (skip on contention) + a top-level guard so
+ *      --quiet always exits 0. A missed pass is harmless; the next turn retries.
+ *
+ * Usage:
+ *   node reconcile-state.mjs [--tiki-path <path>] [--dry-run] [--quiet]
+ *
+ * Exit codes: always 0 in --quiet (hook mode). Without --quiet: 0 success,
+ * 2 on unexpected error (for tests/manual diagnosis).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import {
+  resolveTikiPath,
+  withStateLock,
+  applyTransition,
+  isLegalTransition,
+} from "./state.mjs";
+
+// Monotonic step ordering — used for the advance-only check.
+const STEP_ORDER = { GET: 0, REVIEW: 1, PLAN: 2, AUDIT: 3, EXECUTE: 4, SHIP: 5 };
+
+// Statuses the reconciler must never override (LLM-set or terminal).
+const FROZEN_STATUSES = new Set(["failed", "paused", "completed"]);
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+    } else {
+      args._.push(a);
+    }
+  }
+  return args;
+}
+
+/** Read + parse state.json defensively (never throws past here). */
+function readStateSafe(tikiPath) {
+  const stateFile = path.join(tikiPath, "state.json");
+  if (!fs.existsSync(stateFile)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+  } catch {
+    return null; // corrupt JSON — skip this pass rather than block
+  }
+}
+
+/** Atomic write (tmp + rename); returns true on success, false on failure. */
+function writeStateSafe(tikiPath, state) {
+  const stateFile = path.join(tikiPath, "state.json");
+  const tmp = stateFile + ".tmp";
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2), "utf-8");
+    fs.renameSync(tmp, stateFile);
+    return true;
+  } catch {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    return false;
+  }
+}
+
+function readPlanSafe(tikiPath, number) {
+  const planFile = path.join(tikiPath, "plans", `issue-${number}.json`);
+  if (!fs.existsSync(planFile)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(planFile, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function inHistory(history, number) {
+  if (!history) return false;
+  const recent = Array.isArray(history.recentIssues) ? history.recentIssues : [];
+  for (const r of recent) {
+    if (r && r.number === number) return true;
+  }
+  return false;
+}
+
+/**
+ * Derive EXECUTE phase progress from a plan's phase statuses, or null if no
+ * phase has started yet. `current` is the phase in flight (or the next one).
+ */
+function derivePhase(plan) {
+  const phases = Array.isArray(plan.phases) ? plan.phases : [];
+  const total = phases.length;
+  if (total === 0) return null;
+  let completed = 0;
+  let anyExecuting = false;
+  for (const p of phases) {
+    if (p && p.status === "completed") completed++;
+    else if (p && p.status === "executing") anyExecuting = true;
+  }
+  if (completed === 0 && !anyExecuting) return null; // execution not started
+  const allDone = completed >= total;
+  const current = allDone ? total : Math.min(completed + 1, total);
+  return { current, total, status: allDone ? "completed" : "executing" };
+}
+
+/**
+ * The furthest (status, step[, phase]) justified by artifacts for an in-flight
+ * issue, or null if nothing is derivable (pre-PLAN — left to #247).
+ */
+function deriveTarget(plan) {
+  if (!plan) return null;
+  const phases = Array.isArray(plan.phases) ? plan.phases : [];
+  if (phases.length === 0) return null; // plan not really written yet
+
+  const phase = derivePhase(plan);
+  if (phase) {
+    // EXECUTE: status stays "executing" even when all phases are done — SHIP is
+    // only signalled by history membership, never fabricated here.
+    return { status: "executing", step: "EXECUTE", phase };
+  }
+  // Plan exists, no phase started yet. Distinguish AUDIT from PLAN via the
+  // audit artifact (plan.audited). Keep status "planning" until a phase runs;
+  // only the step marker advances.
+  if (plan.audited === true) {
+    return { status: "planning", step: "AUDIT" };
+  }
+  return { status: "planning", step: "PLAN" };
+}
+
+/**
+ * Reconcile a single issue entry in place. Returns a small change record or null
+ * if nothing changed. Mutates `state` only via guarded applyTransition / delete.
+ */
+function reconcileEntry(state, workId, entry, history, tikiPath) {
+  if (!entry || entry.type !== "issue" || !entry.issue) return null;
+  const number = entry.issue.number;
+  if (typeof number !== "number") return null;
+
+  const status = entry.status;
+  if (FROZEN_STATUSES.has(status)) return null; // never fight failed/paused/completed
+
+  // --- Completion via history (the authoritative done-signal) ---------------
+  if (inHistory(history, number)) {
+    if (entry.parentRelease) {
+      // Release child: should end as completed; the release teardown keeps it.
+      if (status !== "completed" && isLegalTransition(status, "completed")) {
+        applyTransition(state, {
+          workId,
+          toStatus: "completed",
+          toStep: "SHIP",
+          phase: null,
+          parallelExecution: null,
+          parentRelease: undefined, // preserve
+          issue: null,
+          release: null,
+        });
+        return { workId, action: "completed" };
+      }
+      return null;
+    }
+    // Standalone & already shipped but lingering in activeWork → remove it, so
+    // the display stops showing a stale "executing" for a closed issue.
+    delete state.activeWork[workId];
+    return { workId, action: "removed" };
+  }
+
+  // --- In-flight: advance from artifacts ------------------------------------
+  const plan = readPlanSafe(tikiPath, number);
+  const target = deriveTarget(plan);
+  if (!target) return null;
+
+  const curIdx = STEP_ORDER[entry.pipelineStep] ?? -1;
+  const tgtIdx = STEP_ORDER[target.step] ?? -1;
+
+  const stepAdvances = tgtIdx > curIdx;
+  const phaseAdvances =
+    tgtIdx === curIdx &&
+    target.step === "EXECUTE" &&
+    target.phase &&
+    (target.phase.current > (entry.phase?.current ?? 0) ||
+      entry.phase?.status !== target.phase.status);
+
+  if (!stepAdvances && !phaseAdvances) return null;
+
+  // Legality pre-guard so applyTransition can never die() (would crash the hook).
+  if (!isLegalTransition(status, target.status)) return null;
+
+  applyTransition(state, {
+    workId,
+    toStatus: target.status,
+    toStep: target.step,
+    phase: target.phase ?? null,
+    parallelExecution: null,
+    parentRelease: undefined, // preserve existing
+    issue: null,
+    release: null,
+  });
+  return {
+    workId,
+    action: stepAdvances ? `advanced to ${target.step}` : `phase ${target.phase.current}/${target.phase.total}`,
+  };
+}
+
+/**
+ * Run one reconcile pass. Returns { changes: [...] } (changes empty if nothing
+ * to do or the lock was contended). Writes state.json only when something
+ * actually changed (so the watcher isn't churned every turn).
+ */
+export function reconcile(tikiPath, { dryRun = false } = {}) {
+  const result = { changes: [] };
+
+  const pass = () => {
+    const state = readStateSafe(tikiPath);
+    if (!state || typeof state !== "object") return;
+    state.activeWork = state.activeWork || {};
+    const history = state.history || {};
+
+    for (const [workId, entry] of Object.entries(state.activeWork)) {
+      if (!workId.startsWith("issue:")) continue; // leave release:* untouched
+      const change = reconcileEntry(state, workId, entry, history, tikiPath);
+      if (change) result.changes.push(change);
+    }
+
+    if (!dryRun && result.changes.length > 0) {
+      writeStateSafe(tikiPath, state);
+    }
+  };
+
+  if (dryRun) {
+    pass();
+  } else {
+    // Lenient: a contended lock returns undefined and we simply skip this pass.
+    withStateLock(tikiPath, pass, { lenient: true });
+  }
+
+  return result;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const quiet = args.quiet === true;
+  const dryRun = args["dry-run"] === true;
+
+  try {
+    const tikiPath = resolveTikiPath(args["tiki-path"]);
+    const result = reconcile(tikiPath, { dryRun });
+    if (!quiet) {
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    }
+    process.exit(0);
+  } catch (e) {
+    // Hook mode must never block the turn; swallow and exit 0.
+    if (!quiet) {
+      process.stderr.write(`reconcile-state.mjs: ${e.message}\n`);
+      process.exit(2);
+    }
+    process.exit(0);
+  }
+}
+
+import { fileURLToPath } from "node:url";
+const isCliEntry = (() => {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const entryFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+    return entryFile !== null && path.resolve(thisFile) === entryFile;
+  } catch {
+    return false;
+  }
+})();
+
+if (isCliEntry) {
+  main();
+}

--- a/packages/framework/scripts/state.mjs
+++ b/packages/framework/scripts/state.mjs
@@ -333,8 +333,16 @@ function sleepSync(ms) {
 /**
  * Run `fn` while holding an exclusive lock on `<tikiPath>/state.json.lock`.
  * `fn` performs the read-modify-write; serializing it prevents lost updates.
+ *
+ * `opts.lenient` (default false): when a lock cannot be acquired (open error or
+ * acquisition timeout), return `undefined` WITHOUT running `fn` instead of
+ * `die(2)`. The state reconciler (reconcile-state.mjs) runs as a Claude Code
+ * Stop/SubagentStop hook that must never block the user's turn, so it opts in to
+ * lenient locking — a missed reconcile pass is harmless (the next turn retries),
+ * a blocking exit is not. The default (non-lenient) behavior is unchanged.
  */
-function withStateLock(tikiPath, fn) {
+function withStateLock(tikiPath, fn, opts = {}) {
+  const lenient = opts.lenient === true;
   if (!fs.existsSync(tikiPath)) {
     fs.mkdirSync(tikiPath, { recursive: true });
   }
@@ -351,6 +359,7 @@ function withStateLock(tikiPath, fn) {
       break;
     } catch (e) {
       if (e.code !== "EEXIST") {
+        if (lenient) return undefined;
         die(2, `failed to acquire state lock ${lockPath}: ${e.message}`);
       }
       // Lock is held. Steal it if the holder died and left it stale.
@@ -369,6 +378,7 @@ function withStateLock(tikiPath, fn) {
         continue;
       }
       if (Date.now() - start > MAX_WAIT_MS) {
+        if (lenient) return undefined;
         die(2, `timed out after ${MAX_WAIT_MS}ms waiting for state lock ${lockPath}`);
       }
       sleepSync(RETRY_MS);
@@ -846,6 +856,14 @@ if (isCliEntry) {
 }
 
 // Named exports for test/programmatic use. The CLI entry point above is
-// unaffected by these — they exist purely so tests can import the
-// resolver directly without spawning a subprocess for every assertion.
-export { resolveTikiPath };
+// unaffected by these — they exist purely so tests and the state reconciler
+// (reconcile-state.mjs, epic #244) can reuse the validated transition logic
+// in-process instead of duplicating the legal-transition table a fourth time.
+export {
+  resolveTikiPath,
+  readState,
+  writeStateAtomic,
+  withStateLock,
+  applyTransition,
+  isLegalTransition,
+};

--- a/packages/shared/schemas/plan.schema.json
+++ b/packages/shared/schemas/plan.schema.json
@@ -56,6 +56,15 @@
       "format": "date-time",
       "description": "When this plan was last modified"
     },
+    "audited": {
+      "type": "boolean",
+      "description": "True once AUDIT passed for this plan. This is the on-disk artifact that lets the state reconciler distinguish AUDIT from PLAN (audit emits no other durable signal). Written by /tiki:audit on PASS."
+    },
+    "auditedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When AUDIT last passed for this plan"
+    },
     "successCriteria": {
       "type": "array",
       "description": "What needs to be true for this issue to be considered complete",

--- a/packages/shared/src/types/plan.ts
+++ b/packages/shared/src/types/plan.ts
@@ -103,6 +103,14 @@ export interface TikiPlan {
   phases: Phase[];
   /** Maps success criteria IDs to the phases that address them */
   coverageMatrix?: CoverageMatrix;
+  /**
+   * True once AUDIT passed for this plan. The on-disk artifact the state
+   * reconciler uses to distinguish AUDIT from PLAN (audit emits no other
+   * durable signal). Written by /tiki:audit on PASS.
+   */
+  audited?: boolean;
+  /** When AUDIT last passed for this plan */
+  auditedAt?: Timestamp;
   /** Research documents referenced during planning */
   research?: string[];
   /** Additional planning notes or context */


### PR DESCRIPTION
Implements the keystone of epic #244 — flips pipeline-state tracking from an advisory **"report"** contract (the LLM must remember to run `state.mjs transition` each step) to an enforced **"reconcile"** contract (the system recomputes state from artifacts every turn). Fixes the recurring "pipeline freezes mid-run, jumps to Done at the end" symptom.

Built in the review-corrected order after a red-team design review returned NO-GO on the original #245 spec (see the #245 comment for the 8 corrections).

## What's in this PR

**#247 — unconditional foreground transitions**
- Removed the Pattern A/B conditional trap from `yolo.md`; transitions are now always emitted from the parent (double-emit is a safe no-op).
- Every step skill's `<state-management>` reframed as a mandatory first action.
- Fixed a latent drop-cause: `audit.md` lacked `Bash` in its frontmatter, so standalone `/tiki:audit` couldn't run its own transition.
- New regression test blocks the trap from returning.

**Audit artifact** — `audited`/`auditedAt` on the plan schema + Rust `TikiPlan` + TS `TikiPlan` (cross-language parity); `mark-audited.mjs`; `audit.md` writes it on PASS so the reconciler can distinguish AUDIT from PLAN.

**#245 — `reconcile-state.mjs` + `Stop`/`SubagentStop` hooks**
- Derives `pipelineStep`/`status`/`phase` from artifacts (plan file + history).
- activeWork-scoped (never resurrects the ~100 stale plan files), advance-only, skips `failed`/`paused`/`completed`, completion from `history.recentIssues` (no per-turn `gh`), legality pre-guarded so it can never `die()`/block, leaves `release:*`/`parentRelease` intact.
- Reuses `state.mjs` internals (now exported) + a new `lenient` lock mode so the hook never blocks the turn.

**#248 — runtime reconciliation tests** (14) including both review traps (a `failed` item with advanced artifacts is untouched; a stale all-complete plan is not resurrected) and the **drop-resilience proof**: correct EXECUTE state with zero imperative transitions after GET.

## Verification
framework `node:test` 48/48 · shared vitest 86 · desktop vitest 181 · `cargo test` pass · `pnpm build` + `cargo check` clean.

## Notes
- The `Stop`/`SubagentStop` hooks require approval in Claude Code and only affect future runs.
- Hook command uses a relative path (not `$CLAUDE_PROJECT_DIR`) because Windows `cmd.exe` won't expand the variable; the reconciler self-locates `.tiki` via `resolveTikiPath`.

Still to come on this branch: #246 (display reads plan file + stale anomaly) and #249 (watcher hardening).

Closes #245, #247, #248
Part of #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
