### PR TITLE
fix(dist): reconciler reaches installed projects — two-channel (plugin + copy-install) (#251)

### DIFF
--- a/.claude/commands/tiki/audit.md
+++ b/.claude/commands/tiki/audit.md
@@ -143,10 +143,10 @@ If any phase has no `dependencies` field, treat it as an empty list (no deps).
 
 ```bash
 # PASS — record the verdict AND the durable artifact:
-node packages/framework/scripts/mark-audited.mjs {number}
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status executing --to-step AUDIT
+node .claude/tiki/scripts/mark-audited.mjs {number}
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status executing --to-step AUDIT
 # WARN or FAIL — do NOT mark audited; keep planning:
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status planning --to-step AUDIT
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status planning --to-step AUDIT
 ```
 </state-management>
 

--- a/.claude/commands/tiki/execute.md
+++ b/.claude/commands/tiki/execute.md
@@ -56,10 +56,10 @@ Update `.tiki/state.json` BEFORE each phase. On failure, set `phase.status: "fai
 
 ```bash
 # Before phase N:
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status executing --to-step EXECUTE --phase-current {N} --phase-total {T} --phase-status executing
 # All phases done:
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status shipping --to-step SHIP
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status shipping --to-step SHIP
 ```
 </state-update-requirement>
 
@@ -72,19 +72,19 @@ EXECUTE fires four lifecycle hooks via the hook runner. Hooks are **opt-in** —
 
 ```bash
 # Once, BEFORE the first phase (after computing the total phase count):
-node packages/framework/scripts/run-hook.mjs pre-execute \
+node .claude/tiki/scripts/run-hook.mjs pre-execute \
   --env TIKI_ISSUE={number} --env TIKI_TITLE="{issue title}" --env TIKI_TOTAL_PHASES={T}
 
 # Immediately BEFORE starting each phase N (after the state.mjs transition):
-node packages/framework/scripts/run-hook.mjs phase-start \
+node .claude/tiki/scripts/run-hook.mjs phase-start \
   --env TIKI_ISSUE={number} --env TIKI_PHASE={N} --env TIKI_PHASE_TITLE="{phase title}"
 
 # Immediately AFTER each phase N returns (status is "completed" | "failed" | "skipped"):
-node packages/framework/scripts/run-hook.mjs phase-complete \
+node .claude/tiki/scripts/run-hook.mjs phase-complete \
   --env TIKI_ISSUE={number} --env TIKI_PHASE={N} --env TIKI_PHASE_STATUS="{phase status}"
 
 # Once, AFTER all phases finish (before the shipping transition):
-node packages/framework/scripts/run-hook.mjs post-execute \
+node .claude/tiki/scripts/run-hook.mjs post-execute \
   --env TIKI_ISSUE={number} --env TIKI_PHASES_COMPLETED={count of completed phases}
 ```
 

--- a/.claude/commands/tiki/get.md
+++ b/.claude/commands/tiki/get.md
@@ -26,7 +26,7 @@ Fetch a GitHub issue and display it in a readable format. This is typically the 
 **REQUIRED — run this immediately after fetching the issue (you now have the title), before displaying anything.** This creates the `issue:{number}` entry the desktop app tracks; skip it and the issue never appears in the pipeline. Re-running is a safe no-op. Canonical shape and parent-release detection: see `yolo.md` `<state-management>`.
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status pending --to-step GET --issue-number {number} --issue-title "{title}"
 ```
 

--- a/.claude/commands/tiki/plan.md
+++ b/.claude/commands/tiki/plan.md
@@ -164,7 +164,7 @@ Rules:
 **REQUIRED — run this FIRST, before designing any phases.** Set the `issue:{number}` entry to `status: "planning"`, `pipelineStep: "PLAN"` so the desktop pipeline advances to PLAN immediately. Emit it unconditionally as the first action regardless of how this command was invoked; it is a safe no-op if already recorded (shim; see `yolo.md` for the legacy direct-write shape):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status planning --to-step PLAN --issue-number {number} --issue-title "{title}"
 ```
 </early-state-update>
@@ -221,7 +221,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 After writing the plan, set phase progress (`current: 1`, `total: N`, `status: "pending"`). Keep work `status: "planning"` until audit passes.
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status planning --to-step PLAN --phase-current 1 --phase-total {total} --phase-status pending
 ```
 </state-management>

--- a/.claude/commands/tiki/release.md
+++ b/.claude/commands/tiki/release.md
@@ -154,7 +154,7 @@ For each issue, derive a likely-touched-files set from its body using these sign
   - `sidebar` → `apps/desktop/src/components/sidebar/**`
   - `footer` / `header` → `apps/desktop/src/components/Header.*`
   - `github API`, `gh CLI`, `rate limit` → `apps/desktop/src-tauri/src/github.rs`
-  - `state.json`, `state shim`, `transition` → `packages/framework/scripts/state.mjs` and `apps/desktop/src-tauri/src/state*.rs`
+  - `state.json`, `state shim`, `transition` → `.claude/tiki/scripts/state.mjs` and `apps/desktop/src-tauri/src/state*.rs`
   - `release.md`, `yolo.md`, `framework command` → `packages/framework/commands/**`
   - `detail panel`, `issue detail` → `apps/desktop/src/components/detail/**`
 - **GitHub labels** — `desktop` widens scope to `apps/desktop/**`, `rust` narrows to `apps/desktop/src-tauri/**`, `framework` narrows to `packages/framework/**`.
@@ -248,14 +248,14 @@ Release lifecycle: **start** → **per-wave** → **ship**. See `yolo.md` `<stat
 
 ```bash
 # Start:
-node packages/framework/scripts/state.mjs transition release:{version} \
+node .claude/tiki/scripts/state.mjs transition release:{version} \
   --to-status executing --to-step EXECUTE --release-version {version} --release-issues "41,42,43"
 # Per wave: update release.currentIssues (array; direct JSON write — shim does not edit nested release.* fields),
 # spawn one Agent per issue with isolation: 'worktree', wait for the wave to drain, then
 # append each completed issue number to release.completedIssues and each worktree branch
 # name to release.completedBranches (also direct JSON writes).
 # Ship:
-node packages/framework/scripts/state.mjs transition release:{version} --to-status shipping --to-step SHIP
+node .claude/tiki/scripts/state.mjs transition release:{version} --to-status shipping --to-step SHIP
 ```
 
 **Release state shape** (additive — `currentIssue` retained for back-compat with serial mode and is ignored when `currentIssues` is set):
@@ -279,17 +279,17 @@ After shipping:
 
 ```bash
 # Remove the release entry from activeWork:
-node packages/framework/scripts/state.mjs remove release:{version}
+node .claude/tiki/scripts/state.mjs remove release:{version}
 # For EACH child issue with parentRelease == {version} (run the next two lines
 # once per child): append it to history.recentIssues FIRST (so the desktop
 # Kanban "Completed" column, which reads recentIssues, shows release-shipped
 # issues — mirrors ship.md), THEN remove it from activeWork. append-history is
 # idempotent on issue number, so this is safe even if ship.md already appended
 # the child during the cascade.
-node packages/framework/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
-node packages/framework/scripts/state.mjs remove issue:{number}
+node .claude/tiki/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
+node .claude/tiki/scripts/state.mjs remove issue:{number}
 # Append the release completion record to history:
-node packages/framework/scripts/state.mjs append-history release --version {version} --issues "41,42,43" --tag {version}
+node .claude/tiki/scripts/state.mjs append-history release --version {version} --issues "41,42,43" --tag {version}
 ```
 
 Then move the release file to `.tiki/releases/archive/` as a regular filesystem rename (no shim involvement — it's not a state.json mutation).

--- a/.claude/commands/tiki/review.md
+++ b/.claude/commands/tiki/review.md
@@ -140,7 +140,7 @@ Rules:
 **REQUIRED — run this FIRST, before analyzing the issue.** Record the `pending → reviewing` transition through the validated shim so the desktop pipeline advances to REVIEW immediately. Do NOT defer it to the end of the step or make it conditional on how this command was invoked — emit it unconditionally as the first action. The shim creates the `issue:{number}` entry if missing, updates status/`pipelineStep`/`lastActivity`, preserves `parentRelease`, and is a safe no-op if the step was already recorded.
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status reviewing --to-step REVIEW --issue-number {number} --issue-title "{title}"
 ```
 </state-management>

--- a/.claude/commands/tiki/ship.md
+++ b/.claude/commands/tiki/ship.md
@@ -133,12 +133,12 @@ SHIP fires two lifecycle hooks via the hook runner. Hooks are **opt-in** — the
 
 ```bash
 # BEFORE staging/committing (after pre-ship tests pass):
-node packages/framework/scripts/run-hook.mjs pre-ship \
+node .claude/tiki/scripts/run-hook.mjs pre-ship \
   --env TIKI_ISSUE={number} --env TIKI_TITLE="{issue title}"
 
 # AFTER a successful push (capture the commit SHA first):
 SHA=$(git rev-parse HEAD)
-node packages/framework/scripts/run-hook.mjs post-ship \
+node .claude/tiki/scripts/run-hook.mjs post-ship \
   --env TIKI_ISSUE={number} --env TIKI_COMMIT_SHA="$SHA"
 ```
 
@@ -245,13 +245,13 @@ All success criteria verified:
 
 ```bash
 # 1. Mark shipping:
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status shipping --to-step SHIP
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status shipping --to-step SHIP
 # 2a. Release child (entry stays in activeWork; parentRelease preserved):
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status completed --to-step SHIP
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status completed --to-step SHIP
 # 2b. Standalone: remove the issue:{number} key from activeWork:
-node packages/framework/scripts/state.mjs remove issue:{number}
+node .claude/tiki/scripts/state.mjs remove issue:{number}
 # 3. In both cases, append the completion record to history:
-node packages/framework/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
+node .claude/tiki/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
 ```
 
 The plan file at `.tiki/plans/issue-{number}.json` is moved to `.tiki/plans/archive/` as a regular filesystem rename (no shim involvement — it's not a state.json mutation).

--- a/.claude/commands/tiki/yolo.md
+++ b/.claude/commands/tiki/yolo.md
@@ -141,10 +141,12 @@ The desktop kanban board reads `.tiki/state.json` to render pipeline progress. I
 
 Run the matching block BEFORE dispatching that step. The shim validates transitions, atomic-writes, and preserves `parentRelease`.
 
+**If the shim path does not resolve** (e.g. a plugin-only project where `.claude/tiki/scripts/` was not installed, so `node .claude/tiki/scripts/state.mjs` errors with "Cannot find module"), DO NOT skip the state update — fall back to the direct-JSON write in **Legacy: direct JSON** below. (The reconciler hook still corrects state from artifacts, but emitting the transition keeps the kanban live mid-step.)
+
 **Before GET** (fresh issue — initializes the entry; pass `--issue-number` + `--issue-title` so the work item materializes):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status pending --to-step GET \
   --issue-number {number} --issue-title "{title}"
 ```
@@ -152,14 +154,14 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 **Before REVIEW**:
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status reviewing --to-step REVIEW
 ```
 
 **Before PLAN** (phase total `N` is provisional — re-emit after plan.md writes the real count):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status planning --to-step PLAN \
   --phase-current 1 --phase-total {N} --phase-status pending
 ```
@@ -167,7 +169,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 **Before AUDIT** (same `status: planning`, but `pipelineStep` advances to `AUDIT`):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status planning --to-step AUDIT \
   --phase-current 1 --phase-total {N} --phase-status pending
 ```
@@ -175,7 +177,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 **Before EXECUTE** (each phase — `{current}` is the phase about to run, `{total}` is the plan's phase count):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status executing --to-step EXECUTE \
   --phase-current {current} --phase-total {total} --phase-status executing
 ```
@@ -183,7 +185,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 **Before SHIP** (after all phases pass):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status shipping --to-step SHIP
 ```
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node packages/framework/scripts/reconcile-state.mjs --quiet"
+            "command": "node .claude/tiki/scripts/reconcile-state.mjs --quiet"
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node packages/framework/scripts/reconcile-state.mjs --quiet"
+            "command": "node .claude/tiki/scripts/reconcile-state.mjs --quiet"
           }
         ]
       }

--- a/.claude/tiki/scripts/mark-audited.mjs
+++ b/.claude/tiki/scripts/mark-audited.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Tiki AUDIT-artifact writer.
+ *
+ * AUDIT is the one pipeline step that produces no durable on-disk signal of its
+ * own: `coverageMatrix` is written by PLAN, and audit.md only READS the plan.
+ * That left the state reconciler (issue #245 / epic #244) unable to distinguish
+ * AUDIT from PLAN. This script writes the missing artifact — `audited: true` +
+ * `auditedAt` — onto `.tiki/plans/issue-<n>.json`, so the reconciler can derive
+ * the AUDIT step from disk even when the imperative state.mjs transition was
+ * dropped.
+ *
+ * Usage:
+ *   node mark-audited.mjs <issue-number> [--tiki-path <path>] [--dry-run]
+ *
+ * Run by /tiki:audit on PASS (see audit.md <state-management>). Idempotent:
+ * re-running just refreshes auditedAt. Node built-ins only (mirrors state.mjs).
+ *
+ * Exit codes: 0 success · 1 bad args / missing plan · 2 I/O error.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { resolveTikiPath } from "./state.mjs";
+
+function die(code, msg) {
+  process.stderr.write(`mark-audited.mjs: ${msg}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+    } else {
+      args._.push(a);
+    }
+  }
+  return args;
+}
+
+function writeJsonAtomic(file, obj) {
+  const tmp = file + ".tmp";
+  const json = JSON.stringify(obj, null, 2);
+  try {
+    fs.writeFileSync(tmp, json, "utf-8");
+    fs.renameSync(tmp, file);
+  } catch (e) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    die(2, `failed to write ${file}: ${e.message}`);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const raw = args._[0];
+  const number = Number(raw);
+  if (!Number.isInteger(number) || number < 1) {
+    die(1, `missing/invalid <issue-number> (got '${raw}')`);
+  }
+
+  const tikiPath = resolveTikiPath(args["tiki-path"]);
+  const planFile = path.join(tikiPath, "plans", `issue-${number}.json`);
+  if (!fs.existsSync(planFile)) {
+    die(1, `no plan file at ${planFile} — run /tiki:plan ${number} first`);
+  }
+
+  let plan;
+  try {
+    plan = JSON.parse(fs.readFileSync(planFile, "utf-8"));
+  } catch (e) {
+    die(2, `plan file is not valid JSON: ${e.message}`);
+  }
+
+  plan.audited = true;
+  plan.auditedAt = new Date().toISOString();
+
+  if (args["dry-run"] !== true) {
+    writeJsonAtomic(planFile, plan);
+  }
+
+  process.stdout.write(
+    JSON.stringify({ issue: number, audited: true, auditedAt: plan.auditedAt }, null, 2) + "\n"
+  );
+}
+
+import { fileURLToPath } from "node:url";
+const isCliEntry = (() => {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const entryFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+    return entryFile !== null && path.resolve(thisFile) === entryFile;
+  } catch {
+    return false;
+  }
+})();
+
+if (isCliEntry) {
+  main();
+}

--- a/.claude/tiki/scripts/reconcile-state.mjs
+++ b/.claude/tiki/scripts/reconcile-state.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+/**
+ * reconcile-state.mjs — derive pipeline state from on-disk artifacts.
+ *
+ * Epic #244 / issue #245. Tiki's pipeline tracking has historically been a
+ * "report" contract: each /tiki step must remember to run `state.mjs transition`
+ * before it. When the LLM forgets (common in long EXECUTE runs / sub-agent
+ * dispatch), the desktop kanban freezes mid-pipeline. This reconciler flips the
+ * write side to a "reconcile" contract: it RECOMPUTES each active issue's true
+ * pipeline step from artifacts the work physically had to produce, so a dropped
+ * transition self-heals on the next pass.
+ *
+ * It is meant to run as a Claude Code `Stop` AND `SubagentStop` hook (see
+ * .claude/settings.json) so it fires after every assistant/sub-agent turn —
+ * independent of whether the imperative transition ran.
+ *
+ * SAFETY CONTRACT (every rule here is a fix for a real trap found in design
+ * review — do not relax without re-reviewing):
+ *
+ *   1. activeWork-scoped. ONLY mutates issue entries that ALREADY exist in
+ *      state.activeWork. It never scans plan files to CREATE entries — the repo
+ *      has ~100 live plan files for long-shipped issues (plan archiving is
+ *      dropped as often as transitions), and resurrecting them would flood the
+ *      kanban. Early steps (GET→PLAN, before an entry exists) are covered by the
+ *      unconditional foreground transitions from #247, not by this reconciler.
+ *   2. Advance-only. Never moves an item backward; only forward when artifacts
+ *      justify a later step (or more phase progress) than currently recorded.
+ *   3. Skips LLM-set / terminal states. Never touches status failed | paused |
+ *      completed — those are decisions the artifacts can't override.
+ *   4. Completion comes from history, not plan phases. "All phases complete"
+ *      does NOT mean shipped (no ship/archive artifact is reliable). The
+ *      authoritative done-signal is membership in history.recentIssues.
+ *   5. Legality pre-guarded. Every advance is checked with isLegalTransition
+ *      BEFORE applyTransition, so applyTransition can never die() and crash the
+ *      hook. release:* entries and parentRelease are left untouched.
+ *   6. Never blocks. Lenient locking (skip on contention) + a top-level guard so
+ *      --quiet always exits 0. A missed pass is harmless; the next turn retries.
+ *
+ * Usage:
+ *   node reconcile-state.mjs [--tiki-path <path>] [--dry-run] [--quiet]
+ *
+ * Exit codes: always 0 in --quiet (hook mode). Without --quiet: 0 success,
+ * 2 on unexpected error (for tests/manual diagnosis).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import {
+  resolveTikiPath,
+  withStateLock,
+  applyTransition,
+  isLegalTransition,
+} from "./state.mjs";
+
+// Monotonic step ordering — used for the advance-only check.
+const STEP_ORDER = { GET: 0, REVIEW: 1, PLAN: 2, AUDIT: 3, EXECUTE: 4, SHIP: 5 };
+
+// Statuses the reconciler must never override (LLM-set or terminal).
+const FROZEN_STATUSES = new Set(["failed", "paused", "completed"]);
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+    } else {
+      args._.push(a);
+    }
+  }
+  return args;
+}
+
+/** Read + parse state.json defensively (never throws past here). */
+function readStateSafe(tikiPath) {
+  const stateFile = path.join(tikiPath, "state.json");
+  if (!fs.existsSync(stateFile)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+  } catch {
+    return null; // corrupt JSON — skip this pass rather than block
+  }
+}
+
+/** Atomic write (tmp + rename); returns true on success, false on failure. */
+function writeStateSafe(tikiPath, state) {
+  const stateFile = path.join(tikiPath, "state.json");
+  const tmp = stateFile + ".tmp";
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2), "utf-8");
+    fs.renameSync(tmp, stateFile);
+    return true;
+  } catch {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    return false;
+  }
+}
+
+function readPlanSafe(tikiPath, number) {
+  const planFile = path.join(tikiPath, "plans", `issue-${number}.json`);
+  if (!fs.existsSync(planFile)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(planFile, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function inHistory(history, number) {
+  if (!history) return false;
+  const recent = Array.isArray(history.recentIssues) ? history.recentIssues : [];
+  for (const r of recent) {
+    if (r && r.number === number) return true;
+  }
+  return false;
+}
+
+/**
+ * Derive EXECUTE phase progress from a plan's phase statuses, or null if no
+ * phase has started yet. `current` is the phase in flight (or the next one).
+ */
+function derivePhase(plan) {
+  const phases = Array.isArray(plan.phases) ? plan.phases : [];
+  const total = phases.length;
+  if (total === 0) return null;
+  let completed = 0;
+  let anyExecuting = false;
+  for (const p of phases) {
+    if (p && p.status === "completed") completed++;
+    else if (p && p.status === "executing") anyExecuting = true;
+  }
+  if (completed === 0 && !anyExecuting) return null; // execution not started
+  const allDone = completed >= total;
+  const current = allDone ? total : Math.min(completed + 1, total);
+  return { current, total, status: allDone ? "completed" : "executing" };
+}
+
+/**
+ * The furthest (status, step[, phase]) justified by artifacts for an in-flight
+ * issue, or null if nothing is derivable (pre-PLAN — left to #247).
+ */
+function deriveTarget(plan) {
+  if (!plan) return null;
+  const phases = Array.isArray(plan.phases) ? plan.phases : [];
+  if (phases.length === 0) return null; // plan not really written yet
+
+  const phase = derivePhase(plan);
+  if (phase) {
+    // EXECUTE: status stays "executing" even when all phases are done — SHIP is
+    // only signalled by history membership, never fabricated here.
+    return { status: "executing", step: "EXECUTE", phase };
+  }
+  // Plan exists, no phase started yet. Distinguish AUDIT from PLAN via the
+  // audit artifact (plan.audited). Keep status "planning" until a phase runs;
+  // only the step marker advances.
+  if (plan.audited === true) {
+    return { status: "planning", step: "AUDIT" };
+  }
+  return { status: "planning", step: "PLAN" };
+}
+
+/**
+ * Reconcile a single issue entry in place. Returns a small change record or null
+ * if nothing changed. Mutates `state` only via guarded applyTransition / delete.
+ */
+function reconcileEntry(state, workId, entry, history, tikiPath) {
+  if (!entry || entry.type !== "issue" || !entry.issue) return null;
+  const number = entry.issue.number;
+  if (typeof number !== "number") return null;
+
+  const status = entry.status;
+  if (FROZEN_STATUSES.has(status)) return null; // never fight failed/paused/completed
+
+  // --- Completion via history (the authoritative done-signal) ---------------
+  if (inHistory(history, number)) {
+    if (entry.parentRelease) {
+      // Release child: should end as completed; the release teardown keeps it.
+      if (status !== "completed" && isLegalTransition(status, "completed")) {
+        applyTransition(state, {
+          workId,
+          toStatus: "completed",
+          toStep: "SHIP",
+          phase: null,
+          parallelExecution: null,
+          parentRelease: undefined, // preserve
+          issue: null,
+          release: null,
+        });
+        return { workId, action: "completed" };
+      }
+      return null;
+    }
+    // Standalone & already shipped but lingering in activeWork → remove it, so
+    // the display stops showing a stale "executing" for a closed issue.
+    delete state.activeWork[workId];
+    return { workId, action: "removed" };
+  }
+
+  // --- In-flight: advance from artifacts ------------------------------------
+  const plan = readPlanSafe(tikiPath, number);
+  const target = deriveTarget(plan);
+  if (!target) return null;
+
+  const curIdx = STEP_ORDER[entry.pipelineStep] ?? -1;
+  const tgtIdx = STEP_ORDER[target.step] ?? -1;
+
+  const stepAdvances = tgtIdx > curIdx;
+  const phaseAdvances =
+    tgtIdx === curIdx &&
+    target.step === "EXECUTE" &&
+    target.phase &&
+    (target.phase.current > (entry.phase?.current ?? 0) ||
+      entry.phase?.status !== target.phase.status);
+
+  if (!stepAdvances && !phaseAdvances) return null;
+
+  // Legality pre-guard so applyTransition can never die() (would crash the hook).
+  if (!isLegalTransition(status, target.status)) return null;
+
+  applyTransition(state, {
+    workId,
+    toStatus: target.status,
+    toStep: target.step,
+    phase: target.phase ?? null,
+    parallelExecution: null,
+    parentRelease: undefined, // preserve existing
+    issue: null,
+    release: null,
+  });
+  return {
+    workId,
+    action: stepAdvances ? `advanced to ${target.step}` : `phase ${target.phase.current}/${target.phase.total}`,
+  };
+}
+
+/**
+ * Run one reconcile pass. Returns { changes: [...] } (changes empty if nothing
+ * to do or the lock was contended). Writes state.json only when something
+ * actually changed (so the watcher isn't churned every turn).
+ */
+export function reconcile(tikiPath, { dryRun = false } = {}) {
+  const result = { changes: [] };
+
+  const pass = () => {
+    const state = readStateSafe(tikiPath);
+    if (!state || typeof state !== "object") return;
+    state.activeWork = state.activeWork || {};
+    const history = state.history || {};
+
+    for (const [workId, entry] of Object.entries(state.activeWork)) {
+      if (!workId.startsWith("issue:")) continue; // leave release:* untouched
+      const change = reconcileEntry(state, workId, entry, history, tikiPath);
+      if (change) result.changes.push(change);
+    }
+
+    if (!dryRun && result.changes.length > 0) {
+      writeStateSafe(tikiPath, state);
+    }
+  };
+
+  if (dryRun) {
+    pass();
+  } else {
+    // Lenient: a contended lock returns undefined and we simply skip this pass.
+    withStateLock(tikiPath, pass, { lenient: true });
+  }
+
+  return result;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const quiet = args.quiet === true;
+  const dryRun = args["dry-run"] === true;
+
+  try {
+    const tikiPath = resolveTikiPath(args["tiki-path"]);
+    const result = reconcile(tikiPath, { dryRun });
+    if (!quiet) {
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    }
+    process.exit(0);
+  } catch (e) {
+    // Hook mode must never block the turn; swallow and exit 0.
+    if (!quiet) {
+      process.stderr.write(`reconcile-state.mjs: ${e.message}\n`);
+      process.exit(2);
+    }
+    process.exit(0);
+  }
+}
+
+import { fileURLToPath } from "node:url";
+const isCliEntry = (() => {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const entryFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+    return entryFile !== null && path.resolve(thisFile) === entryFile;
+  } catch {
+    return false;
+  }
+})();
+
+if (isCliEntry) {
+  main();
+}

--- a/.claude/tiki/scripts/run-hook.mjs
+++ b/.claude/tiki/scripts/run-hook.mjs
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+/**
+ * Tiki lifecycle hook runner.
+ *
+ * Framework command prose (execute.md, ship.md) fires lifecycle hooks by
+ * shelling out to this script rather than by inlining shell snippets. Keeping
+ * the runner in one place makes the hook contract testable (see
+ * __tests__/run-hook.test.mjs) and gives us a single home for the
+ * .ps1-vs-.sh resolution and block-vs-warn failure policy.
+ *
+ * It is the lifecycle-hook counterpart to the state.mjs shim and deliberately
+ * mirrors its conventions: a tiny built-ins-only arg parser, a worktree-aware
+ * `resolveTikiPath()`, `--tiki-path` override, and the same exit-code grammar.
+ * Like state.mjs it depends on ZERO third-party packages (the Windows pnpm
+ * reparse-point block documented in CLAUDE.md makes adding deps painful).
+ *
+ * Hook points + env vars (from docs/DESIGN.md and docs/HOOKS.md):
+ *
+ *   | Hook           | Env vars                                          |
+ *   |----------------|---------------------------------------------------|
+ *   | pre-execute    | TIKI_ISSUE, TIKI_TITLE, TIKI_TOTAL_PHASES         |
+ *   | post-execute   | TIKI_ISSUE, TIKI_PHASES_COMPLETED                 |
+ *   | phase-start    | TIKI_ISSUE, TIKI_PHASE, TIKI_PHASE_TITLE          |
+ *   | phase-complete | TIKI_ISSUE, TIKI_PHASE, TIKI_PHASE_STATUS         |
+ *   | pre-ship       | TIKI_ISSUE, TIKI_TITLE                            |
+ *   | post-ship      | TIKI_ISSUE, TIKI_COMMIT_SHA                       |
+ *
+ * Usage:
+ *
+ *   node run-hook.mjs <hook-name> [--env KEY=VALUE ...] [--tiki-path P] [--debug]
+ *
+ * The registry lives at `.tiki/hooks/hooks.json`:
+ *
+ *   {
+ *     "hooks": {
+ *       "pre-execute": { "script": "pre-execute.sh", "enabled": false },
+ *       "post-ship":   { "script": "post-ship.sh",   "enabled": true  }
+ *     }
+ *   }
+ *
+ * Resolution:
+ *   - If the registry file is missing, the hook is absent, or its `enabled`
+ *     field is not exactly `true`, the runner prints nothing (or a --debug
+ *     line) and exits 0. A disabled hook is a no-op.
+ *   - The hook script is located under `.tiki/hooks/`. The `script` field from
+ *     the registry names the file; if absent it falls back to
+ *     `<hook-name>.{ps1|sh}`.
+ *   - On Windows (`process.platform === 'win32'`) a `.ps1` is preferred when it
+ *     exists (run via `powershell -NoProfile -ExecutionPolicy Bypass -File`).
+ *     Otherwise a `.sh` is run via `bash` (Git Bash). On non-Windows the `.sh`
+ *     is always run via `bash`.
+ *
+ * Failure policy (block vs warn):
+ *   - Hooks whose name starts with `pre-` are BLOCKING: a non-zero child exit
+ *     propagates as the runner's exit code, which PAUSES the pipeline.
+ *   - All other hooks (post-*, phase-*) are WARN-only: a non-zero child exit
+ *     prints a warning to stderr and the runner still exits 0.
+ *
+ * Exit codes:
+ *   0  hook ran successfully, was disabled/absent, or a non-blocking hook
+ *      failed (warn only)
+ *   1  a blocking (pre-*) hook exited non-zero (the child's code, or 1 if the
+ *      child could not be spawned), OR a bad-argument / I/O error in the runner
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// The canonical set of lifecycle hook names. Used for validation and for the
+// default-script fallback. Mirrors docs/DESIGN.md's hook table.
+const KNOWN_HOOKS = new Set([
+  "pre-execute",
+  "post-execute",
+  "phase-start",
+  "phase-complete",
+  "pre-ship",
+  "post-ship",
+]);
+
+// ---------------------------------------------------------------------------
+// Tiny arg parser. Same shape as state.mjs, but `--env` repeats so it
+// accumulates into an array instead of being overwritten.
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { _: [], env: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--env") {
+      const next = argv[i + 1];
+      if (next === undefined) {
+        die(1, "--env requires a KEY=VALUE argument");
+      }
+      args.env.push(next);
+      i++;
+    } else if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+    } else {
+      args._.push(a);
+    }
+  }
+  return args;
+}
+
+function die(code, msg) {
+  process.stderr.write(`run-hook.mjs: ${msg}\n`);
+  process.exit(code);
+}
+
+function debugLog(enabled, msg) {
+  if (enabled) {
+    process.stderr.write(`run-hook.mjs: ${msg}\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Worktree-aware .tiki resolution. Identical algorithm to state.mjs's
+// resolveTikiPath so a hook fired from a worktree CWD reads the main repo's
+// registry, matching where state.json lives.
+// ---------------------------------------------------------------------------
+
+function resolveTikiPath(override) {
+  if (override) return path.resolve(override);
+
+  const cwd = process.cwd();
+  const naive = path.join(cwd, ".tiki");
+
+  let dir = cwd;
+  let resolved = null;
+  while (true) {
+    const gitEntry = path.join(dir, ".git");
+    if (fs.existsSync(gitEntry)) {
+      let stat;
+      try {
+        stat = fs.statSync(gitEntry);
+      } catch {
+        stat = null;
+      }
+      if (stat && stat.isDirectory()) {
+        resolved = path.join(dir, ".tiki");
+      } else if (stat && stat.isFile()) {
+        try {
+          const content = fs.readFileSync(gitEntry, "utf-8");
+          const firstLine = content.split(/\r?\n/, 1)[0] || "";
+          const match = firstLine.match(/^gitdir:\s*(.+)$/);
+          if (match) {
+            const gitDirPath = match[1].trim();
+            const worktreesIdx = gitDirPath.search(/[\\/]worktrees[\\/]/);
+            if (worktreesIdx !== -1) {
+              const mainGitDir = gitDirPath.slice(0, worktreesIdx);
+              const mainRepoRoot = path.dirname(mainGitDir);
+              resolved = path.join(mainRepoRoot, ".tiki");
+            } else {
+              resolved = path.join(dir, ".tiki");
+            }
+          } else {
+            resolved = path.join(dir, ".tiki");
+          }
+        } catch {
+          resolved = path.join(dir, ".tiki");
+        }
+      } else {
+        resolved = path.join(dir, ".tiki");
+      }
+      break;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+
+  if (resolved === null) {
+    return naive;
+  }
+
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Registry loading.
+// ---------------------------------------------------------------------------
+
+/**
+ * Load `.tiki/hooks/hooks.json`. Returns `null` if the file is absent or
+ * unparseable (treated the same as "no hooks configured" → no-op, exit 0).
+ */
+function loadRegistry(hooksDir, debug) {
+  const registryFile = path.join(hooksDir, "hooks.json");
+  if (!fs.existsSync(registryFile)) {
+    debugLog(debug, `no registry at ${registryFile}`);
+    return null;
+  }
+  let raw;
+  try {
+    raw = fs.readFileSync(registryFile, "utf-8");
+  } catch (e) {
+    debugLog(debug, `failed to read ${registryFile}: ${e.message}`);
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch (e) {
+    // A malformed registry should not crash the pipeline — treat as no hooks.
+    debugLog(debug, `registry is not valid JSON (${e.message}); treating as no hooks`);
+    return null;
+  }
+}
+
+/**
+ * Resolve the on-disk hook script path for a hook entry.
+ *
+ * Preference order:
+ *   - On win32: a `.ps1` (run via PowerShell) if it exists, else a `.sh`.
+ *   - On other platforms: a `.sh` (run via bash).
+ *
+ * The base filename comes from the registry `script` field when present,
+ * otherwise `<hook-name>.{ps1|sh}`. When the registry `script` already carries
+ * an extension we try the platform-preferred sibling first, then the named
+ * file itself, so a registry that lists `post-ship.sh` still picks up a
+ * `post-ship.ps1` on Windows.
+ *
+ * Returns `{ file, runner }` or `null` if nothing runnable exists.
+ *   runner: "powershell" | "bash"
+ */
+function resolveHookScript(hooksDir, hookName, scriptField) {
+  const isWin = process.platform === "win32";
+
+  // Build the ordered list of candidate basenames to try.
+  const base = scriptField && typeof scriptField === "string"
+    ? scriptField.replace(/\.(ps1|sh)$/i, "")
+    : hookName;
+
+  const ps1 = base + ".ps1";
+  const sh = base + ".sh";
+
+  // Also honor an exact registry filename if it had an extension we don't
+  // otherwise generate (defensive; normally base+ext covers it).
+  const exact = scriptField && typeof scriptField === "string" ? scriptField : null;
+
+  const candidates = [];
+  if (isWin) {
+    candidates.push({ name: ps1, runner: "powershell" });
+    candidates.push({ name: sh, runner: "bash" });
+  } else {
+    candidates.push({ name: sh, runner: "bash" });
+    // A .ps1 on a non-Windows host is not runnable here; skip it.
+  }
+  if (exact && exact !== ps1 && exact !== sh) {
+    const runner = /\.ps1$/i.test(exact) ? "powershell" : "bash";
+    // Only consider a .ps1 exact match on Windows.
+    if (!(runner === "powershell" && !isWin)) {
+      candidates.push({ name: exact, runner });
+    }
+  }
+
+  for (const cand of candidates) {
+    const full = path.join(hooksDir, cand.name);
+    if (fs.existsSync(full)) {
+      return { file: full, runner: cand.runner };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Env injection.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `--env KEY=VALUE` pairs into an object. Splits on the FIRST `=` so
+ * values may contain `=`. A pair with no `=` is an error.
+ */
+function parseEnvPairs(pairs) {
+  const out = {};
+  for (const pair of pairs) {
+    const idx = pair.indexOf("=");
+    if (idx === -1) {
+      die(1, `--env value '${pair}' is not in KEY=VALUE form`);
+    }
+    const key = pair.slice(0, idx);
+    const value = pair.slice(idx + 1);
+    if (!key) {
+      die(1, `--env value '${pair}' has an empty key`);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Main.
+// ---------------------------------------------------------------------------
+
+function main() {
+  const argv = process.argv.slice(2);
+  const args = parseArgs(argv);
+  const debug = args.debug === true;
+
+  const hookName = args._[0];
+  if (!hookName) {
+    die(1, "missing <hook-name> argument (e.g. 'pre-execute', 'post-ship')");
+  }
+  if (!KNOWN_HOOKS.has(hookName)) {
+    die(
+      1,
+      `unknown hook '${hookName}' (expected one of: ${[...KNOWN_HOOKS].join(", ")})`
+    );
+  }
+
+  const isBlocking = hookName.startsWith("pre-");
+
+  const tikiPath = resolveTikiPath(args["tiki-path"]);
+  const hooksDir = path.join(tikiPath, "hooks");
+
+  const registry = loadRegistry(hooksDir, debug);
+  if (!registry) {
+    // No registry → nothing to run. Not an error.
+    debugLog(debug, `hook '${hookName}' skipped: no registry`);
+    process.exit(0);
+  }
+
+  const hooks = registry.hooks && typeof registry.hooks === "object" ? registry.hooks : {};
+  const entry = hooks[hookName];
+
+  if (!entry || typeof entry !== "object") {
+    debugLog(debug, `hook '${hookName}' skipped: not present in registry`);
+    process.exit(0);
+  }
+
+  if (entry.enabled !== true) {
+    debugLog(debug, `hook '${hookName}' skipped: disabled`);
+    process.exit(0);
+  }
+
+  const resolved = resolveHookScript(hooksDir, hookName, entry.script);
+  if (!resolved) {
+    // Enabled but no script on disk: warn, but do not block (a missing script
+    // for an enabled hook is a config mistake, not a pipeline-stopping event
+    // for post-* hooks; for pre-* hooks we still surface it but exit 0 so a
+    // typo'd path doesn't wedge the pipeline — the warning makes it visible).
+    process.stderr.write(
+      `run-hook.mjs: hook '${hookName}' is enabled but no script was found in ${hooksDir} ` +
+      `(looked for ${entry.script || hookName + ".{ps1|sh}"}). Skipping.\n`
+    );
+    process.exit(0);
+  }
+
+  // Build the child env: process.env overlaid with the injected pairs.
+  const injected = parseEnvPairs(args.env);
+  const childEnv = { ...process.env, ...injected };
+
+  // Build the spawn invocation per runner.
+  let command;
+  let spawnArgs;
+  if (resolved.runner === "powershell") {
+    command = "powershell";
+    spawnArgs = ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", resolved.file];
+  } else {
+    command = "bash";
+    spawnArgs = [resolved.file];
+  }
+
+  debugLog(debug, `running hook '${hookName}' via ${command}: ${resolved.file}`);
+
+  const result = spawnSync(command, spawnArgs, {
+    env: childEnv,
+    stdio: "inherit",
+    encoding: "utf-8",
+  });
+
+  // spawnSync error (e.g. runner binary not found).
+  if (result.error) {
+    const msg =
+      `run-hook.mjs: failed to launch ${command} for hook '${hookName}': ${result.error.message}`;
+    if (isBlocking) {
+      // A blocking hook that cannot even run should pause the pipeline.
+      process.stderr.write(msg + "\n");
+      process.exit(1);
+    }
+    // Non-blocking: warn and continue.
+    process.stderr.write(msg + " (non-blocking — continuing)\n");
+    process.exit(0);
+  }
+
+  const childCode = typeof result.status === "number" ? result.status : 1;
+
+  if (childCode !== 0) {
+    if (isBlocking) {
+      process.stderr.write(
+        `run-hook.mjs: BLOCKING hook '${hookName}' exited ${childCode}; pausing the pipeline.\n`
+      );
+      process.exit(childCode);
+    }
+    process.stderr.write(
+      `run-hook.mjs: WARNING — hook '${hookName}' exited ${childCode} ` +
+      `(non-blocking — continuing).\n`
+    );
+    process.exit(0);
+  }
+
+  debugLog(debug, `hook '${hookName}' completed successfully`);
+  process.exit(0);
+}
+
+// Only run main() when invoked directly as a CLI, not when imported by tests.
+const isCliEntry = (() => {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const entryFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+    return entryFile !== null && path.resolve(thisFile) === entryFile;
+  } catch {
+    return false;
+  }
+})();
+
+if (isCliEntry) {
+  main();
+}
+
+// Named exports for test / programmatic use.
+export { resolveTikiPath, resolveHookScript, parseEnvPairs, loadRegistry, KNOWN_HOOKS };

--- a/.claude/tiki/scripts/state.mjs
+++ b/.claude/tiki/scripts/state.mjs
@@ -1,0 +1,869 @@
+#!/usr/bin/env node
+/**
+ * Tiki state.json CLI shim.
+ *
+ * Claude Code drives the Tiki framework via bash, not Tauri IPC. This script
+ * is the bash-callable counterpart to the typed `state_transition` Tauri
+ * command in `apps/desktop/src-tauri/src/state_transition.rs`. Both
+ * implementations produce the same JSON shape and enforce the same legal
+ * transition table, so framework command prose can call either one and
+ * get a consistent state.json.
+ *
+ * Subcommands:
+ *
+ *   transition <work-id> --to-status <s> [--to-step <S>] [--phase-*] ...
+ *     Mutate status / step / phase on an activeWork entry (creating it if
+ *     this is the first transition). Validates against the legal table.
+ *
+ *   get <work-id> [--field <path>]
+ *     Read an activeWork entry. With --field, returns just that
+ *     dot-path (scalars print raw, objects/arrays as JSON).
+ *
+ *   remove <work-id>
+ *     Delete activeWork[workId]. Used by ship.md when finalizing a
+ *     standalone issue.
+ *
+ *   append-history issue --number N --title "..." [--completed-at ISO]
+ *   append-history release --version V [--issues "1,2,3"] [--tag T] [--completed-at ISO]
+ *     Append a completed-work record to history.recentIssues /
+ *     recentReleases and update history.lastCompletedIssue /
+ *     lastCompletedRelease. Shapes match completedIssueRecord /
+ *     completedReleaseRecord in state.schema.json.
+ *
+ * Common flags:
+ *
+ *   --tiki-path <path>      Override .tiki location (defaults to <cwd>/.tiki).
+ *   --dry-run               Apply in memory and print the would-be result,
+ *                           but do NOT write state.json. Honored by
+ *                           transition, remove, and append-history.
+ *                           Illegal transitions still exit 1.
+ *
+ * Examples:
+ *
+ *   # Fresh GET-step entry for a brand new issue:
+ *   node state.mjs transition issue:42 --to-status pending --to-step GET \
+ *     --issue-number 42 --issue-title "Add user profiles"
+ *
+ *   # Advance to executing during EXECUTE step:
+ *   node state.mjs transition issue:42 --to-status executing --to-step EXECUTE \
+ *     --phase-current 2 --phase-total 5 --phase-status executing
+ *
+ *   # Preview a transition without writing:
+ *   node state.mjs transition issue:42 --to-status shipping --to-step SHIP --dry-run
+ *
+ *   # Read the current status of an issue:
+ *   node state.mjs get issue:42 --field status
+ *
+ *   # Remove a finalized issue from activeWork (standalone ship):
+ *   node state.mjs remove issue:42
+ *
+ *   # Append a completed issue record to history:
+ *   node state.mjs append-history issue --number 42 --title "Add user profiles"
+ *
+ *   # Append a completed release record to history:
+ *   node state.mjs append-history release --version v1.2.0 --issues "41,42,43" --tag v1.2.0
+ *
+ * Exit codes:
+ *   0  success (prints relevant JSON or scalar to stdout)
+ *   1  validation error (illegal transition, bad arguments, missing entry)
+ *   2  I/O error (read/write/atomic-rename failure)
+ *
+ * Backward compatibility:
+ *   The shim is OPTIONAL. Framework commands that still write JSON directly
+ *   to state.json continue to work — the shape this shim produces is
+ *   identical to what the prose-driven approach produces.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+// ---------------------------------------------------------------------------
+// Legal transition table. The canonical table lives at
+// packages/shared/src/types/transitions.ts. This file mirrors it, as does
+// apps/desktop/src-tauri/src/state_transition.rs. All three must be kept in
+// sync (the parity test in packages/shared/src/__tests__/transitions-parity.test.ts
+// enforces this mechanically).
+//
+// Format: from-status -> Set of allowed to-statuses. Same-status transitions
+// (e.g. executing -> executing) are always allowed and not enumerated.
+// ---------------------------------------------------------------------------
+
+const LEGAL = {
+  pending: new Set(["reviewing", "planning", "executing", "paused", "failed"]),
+  reviewing: new Set(["planning", "executing", "paused", "failed"]),
+  planning: new Set(["executing", "paused", "failed"]),
+  executing: new Set(["shipping", "paused", "failed", "completed"]),
+  shipping: new Set(["completed", "failed"]),
+  paused: new Set(["pending", "reviewing", "planning", "executing", "shipping"]),
+  failed: new Set(["pending", "reviewing", "planning", "executing"]),
+  completed: new Set(), // terminal
+};
+
+const VALID_STATUSES = new Set([
+  "pending",
+  "reviewing",
+  "planning",
+  "executing",
+  "paused",
+  "failed",
+  "shipping",
+  "completed",
+]);
+
+const VALID_STEPS = new Set(["GET", "REVIEW", "PLAN", "AUDIT", "EXECUTE", "SHIP"]);
+
+function isLegalTransition(from, to) {
+  if (from === to) return true;
+  const allowed = LEGAL[from];
+  return allowed ? allowed.has(to) : false;
+}
+
+// ---------------------------------------------------------------------------
+// Tiny arg parser. Avoids pulling in yargs/minimist for a single-purpose CLI.
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+    } else {
+      args._.push(a);
+    }
+  }
+  return args;
+}
+
+function die(code, msg) {
+  process.stderr.write(`state.mjs: ${msg}\n`);
+  process.exit(code);
+}
+
+// ---------------------------------------------------------------------------
+// State file I/O.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the `.tiki/` directory path with worktree awareness.
+ *
+ * Resolution rules:
+ *   1. If `override` is provided, honor it exactly (absolute resolved).
+ *   2. Otherwise, walk upward from `process.cwd()` looking for the first
+ *      ancestor that contains a `.git/` entry (directory OR file).
+ *        - `.git` directory  -> normal repo root, return `<ancestor>/.tiki`.
+ *        - `.git` file       -> git worktree marker. Parse `gitdir:` line,
+ *                               extract the path before `/worktrees/<name>`
+ *                               to get the main repo's `.git` directory, go
+ *                               up one level to reach the main repo root,
+ *                               return `<main-repo-root>/.tiki`.
+ *   3. If no ancestor has a `.git`, fall back to `<cwd>/.tiki`.
+ *
+ * Worktree case rationale: sub-agents dispatched with `isolation: "worktree"`
+ * have a CWD inside `<repo>/.git/worktrees/<name>/...`. The Tauri watcher
+ * observes the main repo's `.tiki/state.json`, not the worktree's. Without
+ * this resolution, sub-agent state writes are invisible to the desktop app.
+ *
+ * When auto-resolution produces a path that differs from the naive
+ * `<cwd>/.tiki`, a single-line debug message is emitted on stderr.
+ */
+function resolveTikiPath(override) {
+  if (override) return path.resolve(override);
+
+  const cwd = process.cwd();
+  const naive = path.join(cwd, ".tiki");
+
+  // Walk upward looking for `.git`.
+  let dir = cwd;
+  let resolved = null;
+  while (true) {
+    const gitEntry = path.join(dir, ".git");
+    if (fs.existsSync(gitEntry)) {
+      let stat;
+      try {
+        stat = fs.statSync(gitEntry);
+      } catch {
+        stat = null;
+      }
+      if (stat && stat.isDirectory()) {
+        // Normal repo root.
+        resolved = path.join(dir, ".tiki");
+      } else if (stat && stat.isFile()) {
+        // Worktree marker: read the gitdir pointer.
+        try {
+          const content = fs.readFileSync(gitEntry, "utf-8");
+          const firstLine = content.split(/\r?\n/, 1)[0] || "";
+          const match = firstLine.match(/^gitdir:\s*(.+)$/);
+          if (match) {
+            const gitDirPath = match[1].trim();
+            // Find `/worktrees/<name>` segment and strip it to find main .git.
+            const worktreesIdx = gitDirPath.search(/[\\/]worktrees[\\/]/);
+            if (worktreesIdx !== -1) {
+              const mainGitDir = gitDirPath.slice(0, worktreesIdx);
+              const mainRepoRoot = path.dirname(mainGitDir);
+              resolved = path.join(mainRepoRoot, ".tiki");
+            } else {
+              // Unrecognized .git file format - treat dir as repo root.
+              resolved = path.join(dir, ".tiki");
+            }
+          } else {
+            resolved = path.join(dir, ".tiki");
+          }
+        } catch {
+          resolved = path.join(dir, ".tiki");
+        }
+      } else {
+        // Some other entry type — bail to naive fallback.
+        resolved = path.join(dir, ".tiki");
+      }
+      break;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      // Hit filesystem root with no .git found.
+      break;
+    }
+    dir = parent;
+  }
+
+  if (resolved === null) {
+    // No `.git` ancestor — preserve legacy non-repo behavior.
+    return naive;
+  }
+
+  if (path.resolve(resolved) !== path.resolve(naive)) {
+    process.stderr.write(
+      `state.mjs: resolved tikiPath from worktree to ${resolved}\n`
+    );
+  }
+
+  return resolved;
+}
+
+function readState(tikiPath) {
+  const stateFile = path.join(tikiPath, "state.json");
+  if (!fs.existsSync(stateFile)) {
+    return { schemaVersion: 1, activeWork: {}, history: {} };
+  }
+  let raw;
+  try {
+    raw = fs.readFileSync(stateFile, "utf-8");
+  } catch (e) {
+    die(2, `failed to read ${stateFile}: ${e.message}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    die(2, `state.json is not valid JSON: ${e.message}`);
+  }
+}
+
+function writeStateAtomic(tikiPath, state) {
+  if (!fs.existsSync(tikiPath)) {
+    fs.mkdirSync(tikiPath, { recursive: true });
+  }
+  const stateFile = path.join(tikiPath, "state.json");
+  const tmp = stateFile + ".tmp";
+  const json = JSON.stringify(state, null, 2);
+  try {
+    fs.writeFileSync(tmp, json, "utf-8");
+    fs.renameSync(tmp, stateFile);
+  } catch (e) {
+    // Best-effort cleanup of the temp file.
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    die(2, `failed to write ${stateFile}: ${e.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-process write lock (#224).
+//
+// state.mjs is invoked once per transition, often chained rapidly during a
+// release cascade — and two processes doing read-modify-write on state.json can
+// interleave and LOSE an update (A reads, B reads, A writes, B writes; A's
+// mutation vanishes). writeStateAtomic's temp+rename only protects readers from
+// partial writes, not writers from clobbering each other. We serialize the whole
+// read-modify-write behind an exclusive lockfile.
+//
+// Node built-ins only (the Windows pnpm reparse-point block makes adding deps
+// painful — mirrors the node:test choice). Stale locks (from a crashed/killed
+// holder) are stolen after STALE_MS; an exit handler releases our own lock even
+// when die()/process.exit() unwinds past the finally.
+// ---------------------------------------------------------------------------
+
+let HELD_LOCK = null;
+
+function releaseHeldLock() {
+  if (!HELD_LOCK) return;
+  const { fd, path: lockPath } = HELD_LOCK;
+  HELD_LOCK = null;
+  try {
+    fs.closeSync(fd);
+  } catch {
+    /* ignore */
+  }
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    /* ignore */
+  }
+}
+
+// Fires on normal exit AND process.exit() (which die() calls), so an illegal
+// transition inside the lock never leaves the lockfile behind.
+process.on("exit", releaseHeldLock);
+
+/** Synchronous sleep with zero deps (no busy-spin). */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Run `fn` while holding an exclusive lock on `<tikiPath>/state.json.lock`.
+ * `fn` performs the read-modify-write; serializing it prevents lost updates.
+ *
+ * `opts.lenient` (default false): when a lock cannot be acquired (open error or
+ * acquisition timeout), return `undefined` WITHOUT running `fn` instead of
+ * `die(2)`. The state reconciler (reconcile-state.mjs) runs as a Claude Code
+ * Stop/SubagentStop hook that must never block the user's turn, so it opts in to
+ * lenient locking — a missed reconcile pass is harmless (the next turn retries),
+ * a blocking exit is not. The default (non-lenient) behavior is unchanged.
+ */
+function withStateLock(tikiPath, fn, opts = {}) {
+  const lenient = opts.lenient === true;
+  if (!fs.existsSync(tikiPath)) {
+    fs.mkdirSync(tikiPath, { recursive: true });
+  }
+  const lockPath = path.join(tikiPath, "state.json.lock");
+  const STALE_MS = 10_000;
+  const MAX_WAIT_MS = 5_000;
+  const RETRY_MS = 25;
+  const start = Date.now();
+
+  let fd = null;
+  for (;;) {
+    try {
+      fd = fs.openSync(lockPath, "wx"); // exclusive create — fails if held
+      break;
+    } catch (e) {
+      if (e.code !== "EEXIST") {
+        if (lenient) return undefined;
+        die(2, `failed to acquire state lock ${lockPath}: ${e.message}`);
+      }
+      // Lock is held. Steal it if the holder died and left it stale.
+      try {
+        const st = fs.statSync(lockPath);
+        if (Date.now() - st.mtimeMs > STALE_MS) {
+          try {
+            fs.unlinkSync(lockPath);
+          } catch {
+            /* another writer beat us to it */
+          }
+          continue;
+        }
+      } catch {
+        // Lock vanished between open and stat — retry immediately.
+        continue;
+      }
+      if (Date.now() - start > MAX_WAIT_MS) {
+        if (lenient) return undefined;
+        die(2, `timed out after ${MAX_WAIT_MS}ms waiting for state lock ${lockPath}`);
+      }
+      sleepSync(RETRY_MS);
+    }
+  }
+
+  try {
+    fs.writeSync(fd, String(process.pid));
+  } catch {
+    /* the pid is diagnostic only */
+  }
+  HELD_LOCK = { fd, path: lockPath };
+  try {
+    return fn();
+  } finally {
+    releaseHeldLock();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers.
+// ---------------------------------------------------------------------------
+
+function assertWorkIdShape(workId) {
+  const isIssue = workId.startsWith("issue:");
+  const isRelease = workId.startsWith("release:");
+  if (!isIssue && !isRelease) {
+    die(1, `invalid work_id '${workId}': must start with 'issue:' or 'release:'`);
+  }
+  return { isIssue, isRelease };
+}
+
+function getNested(obj, dotPath) {
+  if (!dotPath) return obj;
+  const parts = dotPath.split(".");
+  let cur = obj;
+  for (const part of parts) {
+    if (cur === null || cur === undefined || typeof cur !== "object") {
+      return undefined;
+    }
+    cur = cur[part];
+  }
+  return cur;
+}
+
+function printValue(value) {
+  // Scalars (string/number/boolean) print raw for shell-friendliness.
+  // Objects, arrays, null → JSON, pretty-printed.
+  if (value === null) {
+    process.stdout.write("null\n");
+    return;
+  }
+  const t = typeof value;
+  if (t === "string" || t === "number" || t === "boolean") {
+    process.stdout.write(String(value) + "\n");
+    return;
+  }
+  process.stdout.write(JSON.stringify(value, null, 2) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: transition
+// ---------------------------------------------------------------------------
+
+function applyTransition(state, input) {
+  const { workId, toStatus, toStep, phase, parallelExecution, parentRelease, issue, release } =
+    input;
+
+  const { isIssue } = assertWorkIdShape(workId);
+
+  state.activeWork = state.activeWork || {};
+  const existing = state.activeWork[workId];
+  const now = new Date().toISOString();
+
+  if (existing) {
+    // Existing entry — validate the transition first.
+    const fromStatus = existing.status;
+    if (!isLegalTransition(fromStatus, toStatus)) {
+      die(1, `illegal transition for ${workId}: ${fromStatus} -> ${toStatus}`);
+    }
+  }
+
+  // Build / update the entry.
+  if (isIssue) {
+    let entry = existing && existing.type === "issue" ? existing : null;
+    if (existing && existing.type !== "issue") {
+      die(1, `work_id ${workId} was previously a ${existing.type}, cannot retype as issue`);
+    }
+    if (!entry) {
+      // Fresh — require the issue payload.
+      if (!issue) {
+        die(1, `creating new entry ${workId} requires --issue-number (and --issue-title)`);
+      }
+      entry = {
+        type: "issue",
+        issue,
+        status: toStatus,
+        ...(toStep ? { pipelineStep: toStep } : {}),
+        createdAt: now,
+        lastActivity: now,
+        ...(parentRelease ? { parentRelease } : {}),
+      };
+    } else {
+      entry.status = toStatus;
+      if (toStep) entry.pipelineStep = toStep;
+      // Preserve parentRelease unless explicitly overwritten.
+      if (parentRelease !== undefined) {
+        entry.parentRelease = parentRelease;
+      }
+      entry.lastActivity = now;
+    }
+
+    if (phase) {
+      entry.phase = phase;
+    }
+    if (parallelExecution) {
+      entry.parallelExecution = parallelExecution;
+    }
+    // Clear parallelExecution on terminal-ish transitions, matching the Rust impl.
+    if (toStatus === "shipping" || toStatus === "completed") {
+      delete entry.parallelExecution;
+    }
+    // Clear stale phase progress on completion so the pipeline timeline and
+    // sidebar don't show a leftover "1/N" after the work is done (#220).
+    // Mirrors the Rust state_transition impl.
+    if (toStatus === "completed") {
+      delete entry.phase;
+    }
+
+    state.activeWork[workId] = entry;
+  } else {
+    // Release branch.
+    let entry = existing && existing.type === "release" ? existing : null;
+    if (existing && existing.type !== "release") {
+      die(1, `work_id ${workId} was previously a ${existing.type}, cannot retype as release`);
+    }
+    if (!entry) {
+      if (!release) {
+        die(1, `creating new entry ${workId} requires --release-version and --release-issues`);
+      }
+      entry = {
+        type: "release",
+        release,
+        status: toStatus,
+        ...(toStep ? { pipelineStep: toStep } : {}),
+        createdAt: now,
+        lastActivity: now,
+      };
+    } else {
+      entry.status = toStatus;
+      if (toStep) entry.pipelineStep = toStep;
+      entry.lastActivity = now;
+    }
+    state.activeWork[workId] = entry;
+  }
+
+  return state.activeWork[workId];
+}
+
+function handleTransition(args) {
+  const workId = args._[1];
+  if (!workId) {
+    die(1, "missing <work-id> argument (e.g. 'issue:42' or 'release:v1.2')");
+  }
+  const toStatus = args["to-status"];
+  if (!toStatus) {
+    die(1, "missing --to-status flag");
+  }
+  if (!VALID_STATUSES.has(toStatus)) {
+    die(
+      1,
+      `invalid --to-status '${toStatus}' (must be one of: ${[...VALID_STATUSES].join(", ")})`
+    );
+  }
+
+  const toStep = args["to-step"];
+  if (toStep && !VALID_STEPS.has(toStep)) {
+    die(1, `invalid --to-step '${toStep}' (must be one of: ${[...VALID_STEPS].join(", ")})`);
+  }
+
+  // Optional phase tri-tuple. All three flags must be provided together.
+  const phaseCurrent = args["phase-current"];
+  const phaseTotal = args["phase-total"];
+  const phaseStatus = args["phase-status"];
+  let phase = null;
+  if (phaseCurrent !== undefined || phaseTotal !== undefined || phaseStatus !== undefined) {
+    if (phaseCurrent === undefined || phaseTotal === undefined || phaseStatus === undefined) {
+      die(
+        1,
+        "--phase-current, --phase-total, and --phase-status must all be provided together"
+      );
+    }
+    phase = {
+      current: Number(phaseCurrent),
+      total: Number(phaseTotal),
+      status: phaseStatus,
+    };
+    if (Number.isNaN(phase.current) || Number.isNaN(phase.total)) {
+      die(1, "--phase-current and --phase-total must be numbers");
+    }
+  }
+
+  // Optional parentRelease.
+  const parentRelease = args["parent-release"];
+
+  // Optional issue payload (for fresh entries).
+  const issueNumber = args["issue-number"];
+  const issueTitle = args["issue-title"];
+  const issue = issueNumber !== undefined
+    ? { number: Number(issueNumber), ...(issueTitle ? { title: issueTitle } : {}) }
+    : null;
+
+  // Optional release payload.
+  const releaseVersion = args["release-version"];
+  const releaseIssuesRaw = args["release-issues"];
+  const release = releaseVersion !== undefined
+    ? {
+        version: releaseVersion,
+        issues: releaseIssuesRaw
+          ? String(releaseIssuesRaw)
+              .split(",")
+              .map((s) => Number(s.trim()))
+              .filter((n) => !Number.isNaN(n))
+          : [],
+        completedIssues: [],
+      }
+    : null;
+
+  // Read existing state, apply, optionally write atomically. The whole
+  // read-modify-write runs under the cross-process lock so chained writes
+  // during a release cascade can't lose an update (#224).
+  const tikiPath = resolveTikiPath(args["tiki-path"]);
+  const dryRun = args["dry-run"] === true;
+
+  let updated;
+  const apply = () => {
+    const state = readState(tikiPath);
+    updated = applyTransition(state, {
+      workId,
+      toStatus,
+      toStep: toStep || null,
+      phase,
+      parallelExecution: null, // not exposed via CLI yet — Rust IPC is canonical for parallel groups
+      parentRelease: parentRelease !== undefined ? parentRelease : undefined,
+      issue,
+      release,
+    });
+    if (!dryRun) {
+      writeStateAtomic(tikiPath, state);
+    }
+  };
+  if (dryRun) apply();
+  else withStateLock(tikiPath, apply);
+
+  // Emit the updated entry as JSON to stdout. Callers can pipe / jq this.
+  process.stdout.write(JSON.stringify(updated, null, 2) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: get
+// ---------------------------------------------------------------------------
+
+function handleGet(args) {
+  const workId = args._[1];
+  if (!workId) {
+    die(1, "missing <work-id> argument (e.g. 'issue:42' or 'release:v1.2')");
+  }
+  assertWorkIdShape(workId);
+
+  const tikiPath = resolveTikiPath(args["tiki-path"]);
+  const state = readState(tikiPath);
+  const entry = (state.activeWork || {})[workId];
+  if (!entry) {
+    die(1, `no active work for '${workId}'`);
+  }
+
+  const field = args.field;
+  if (field === undefined || field === true) {
+    process.stdout.write(JSON.stringify(entry, null, 2) + "\n");
+    return;
+  }
+  const value = getNested(entry, String(field));
+  if (value === undefined) {
+    die(1, `field '${field}' not present on ${workId}`);
+  }
+  printValue(value);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: remove
+// ---------------------------------------------------------------------------
+
+function handleRemove(args) {
+  const workId = args._[1];
+  if (!workId) {
+    die(1, "missing <work-id> argument (e.g. 'issue:42' or 'release:v1.2')");
+  }
+  assertWorkIdShape(workId);
+
+  const tikiPath = resolveTikiPath(args["tiki-path"]);
+  const dryRun = args["dry-run"] === true;
+
+  let entry;
+  const apply = () => {
+    const state = readState(tikiPath);
+    state.activeWork = state.activeWork || {};
+    entry = state.activeWork[workId];
+    if (!entry) {
+      die(1, `no active work for '${workId}'`);
+    }
+    delete state.activeWork[workId];
+    if (!dryRun) {
+      writeStateAtomic(tikiPath, state);
+    }
+  };
+  if (dryRun) apply();
+  else withStateLock(tikiPath, apply);
+
+  // Print the removed entry so callers can see what was deleted.
+  process.stdout.write(JSON.stringify(entry, null, 2) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: append-history
+// ---------------------------------------------------------------------------
+
+function buildCompletedIssueRecord(args) {
+  const numberRaw = args.number;
+  if (numberRaw === undefined || numberRaw === true) {
+    die(1, "append-history issue requires --number N");
+  }
+  const number = Number(numberRaw);
+  if (!Number.isFinite(number) || number < 1) {
+    die(1, `invalid --number '${numberRaw}' (must be a positive integer)`);
+  }
+  const titleRaw = args.title;
+  const title = typeof titleRaw === "string" ? titleRaw : undefined;
+  if (!title) {
+    die(1, "append-history issue requires --title \"...\"");
+  }
+  const completedAtRaw = args["completed-at"];
+  const completedAt =
+    typeof completedAtRaw === "string" ? completedAtRaw : new Date().toISOString();
+
+  return { number, title, completedAt };
+}
+
+function buildCompletedReleaseRecord(args) {
+  const versionRaw = args.version;
+  const version = typeof versionRaw === "string" ? versionRaw : undefined;
+  if (!version) {
+    die(1, "append-history release requires --version V");
+  }
+  const issuesRaw = args.issues;
+  const issues =
+    typeof issuesRaw === "string"
+      ? issuesRaw
+          .split(",")
+          .map((s) => Number(s.trim()))
+          .filter((n) => Number.isFinite(n) && n >= 1)
+      : undefined;
+
+  const tagRaw = args.tag;
+  const tag = typeof tagRaw === "string" ? tagRaw : undefined;
+
+  const completedAtRaw = args["completed-at"];
+  const completedAt =
+    typeof completedAtRaw === "string" ? completedAtRaw : new Date().toISOString();
+
+  return {
+    version,
+    ...(issues !== undefined ? { issues } : {}),
+    completedAt,
+    ...(tag !== undefined ? { tag } : {}),
+  };
+}
+
+function handleAppendHistory(args) {
+  const kind = args._[1];
+  if (kind !== "issue" && kind !== "release") {
+    die(1, `append-history requires 'issue' or 'release' as the second argument (got '${kind}')`);
+  }
+
+  const tikiPath = resolveTikiPath(args["tiki-path"]);
+  const dryRun = args["dry-run"] === true;
+
+  let record;
+  const apply = () => {
+    const state = readState(tikiPath);
+    state.history = state.history || {};
+
+    if (kind === "issue") {
+      record = buildCompletedIssueRecord(args);
+      state.history.recentIssues = Array.isArray(state.history.recentIssues)
+        ? state.history.recentIssues
+        : [];
+      // Idempotent: drop any prior entry for the same issue number before
+      // re-inserting, so re-running append-history (e.g. ship.md during the
+      // cascade AND release.md teardown) never duplicates a child issue.
+      state.history.recentIssues = state.history.recentIssues.filter(
+        (entry) => entry == null || entry.number !== record.number
+      );
+      state.history.recentIssues.unshift(record);
+      state.history.lastCompletedIssue = record;
+    } else {
+      record = buildCompletedReleaseRecord(args);
+      state.history.recentReleases = Array.isArray(state.history.recentReleases)
+        ? state.history.recentReleases
+        : [];
+      // Idempotent: drop any prior entry for the same release version before
+      // re-inserting, so re-running append-history release never duplicates.
+      state.history.recentReleases = state.history.recentReleases.filter(
+        (entry) => entry == null || entry.version !== record.version
+      );
+      state.history.recentReleases.unshift(record);
+      state.history.lastCompletedRelease = record;
+    }
+
+    if (!dryRun) {
+      writeStateAtomic(tikiPath, state);
+    }
+  };
+  if (dryRun) apply();
+  else withStateLock(tikiPath, apply);
+
+  process.stdout.write(JSON.stringify(record, null, 2) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point.
+// ---------------------------------------------------------------------------
+
+function main() {
+  const argv = process.argv.slice(2);
+  const args = parseArgs(argv);
+
+  const subcommand = args._[0];
+  switch (subcommand) {
+    case "transition":
+      handleTransition(args);
+      return;
+    case "get":
+      handleGet(args);
+      return;
+    case "remove":
+      handleRemove(args);
+      return;
+    case "append-history":
+      handleAppendHistory(args);
+      return;
+    default:
+      die(
+        1,
+        `unknown subcommand '${subcommand}' (expected one of: transition, get, remove, append-history)`
+      );
+  }
+}
+
+// Only run main() when this file is invoked directly as a CLI, not when
+// imported as a module by tests. We compare the resolved entry script
+// against this module's URL.
+import { fileURLToPath } from "node:url";
+const isCliEntry = (() => {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const entryFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+    return entryFile !== null && path.resolve(thisFile) === entryFile;
+  } catch {
+    return false;
+  }
+})();
+
+if (isCliEntry) {
+  main();
+}
+
+// Named exports for test/programmatic use. The CLI entry point above is
+// unaffected by these — they exist purely so tests and the state reconciler
+// (reconcile-state.mjs, epic #244) can reuse the validated transition logic
+// in-process instead of duplicating the legal-transition table a fourth time.
+export {
+  resolveTikiPath,
+  readState,
+  writeStateAtomic,
+  withStateLock,
+  applyTransition,
+  isLegalTransition,
+};

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -14,6 +14,12 @@ use tauri_plugin_dialog::DialogExt;
 /// project's `.claude/commands/tiki/` directory offline.
 static FRAMEWORK_COMMANDS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../../packages/framework/commands");
 
+/// Framework scripts embedded at compile time (state.mjs / reconcile-state.mjs /
+/// mark-audited.mjs / run-hook.mjs). Installed into `<project>/.claude/tiki/scripts/`
+/// so command bodies and the reconciler hook can run them in any project, not just
+/// the monorepo (#251 / epic #244).
+static FRAMEWORK_SCRIPTS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../../packages/framework/scripts");
+
 /// Action to apply to a work item via `update_work_status`.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -657,18 +663,103 @@ pub fn install_framework(app: AppHandle, project_path: String) -> Result<String,
         installed += 1;
     }
 
+    // Install the scripts the commands + reconciler hook depend on (#251).
+    let scripts_dir = project.join(".claude").join("tiki").join("scripts");
+    std::fs::create_dir_all(&scripts_dir).map_err(|e| e.to_string())?;
+    let mut scripts_installed = 0;
+    for file in FRAMEWORK_SCRIPTS.files() {
+        let name = file
+            .path()
+            .file_name()
+            .ok_or_else(|| "embedded framework script missing name".to_string())?;
+        std::fs::write(scripts_dir.join(name), file.contents()).map_err(|e| e.to_string())?;
+        scripts_installed += 1;
+    }
+
+    // Register the reconciler Stop/SubagentStop hooks so pipeline state self-heals
+    // even when an imperative transition is dropped (epic #244).
+    ensure_reconciler_hook(&project)?;
+
     let version = app.package_info().version.to_string();
     let tiki_dir = project.join(".tiki");
     std::fs::create_dir_all(&tiki_dir).map_err(|e| e.to_string())?;
     std::fs::write(tiki_dir.join(".framework-version"), &version).map_err(|e| e.to_string())?;
 
     log::info!(
-        "Installed {} framework commands to {:?} (version {})",
+        "Installed {} framework commands + {} scripts to {:?} (version {})",
         installed,
+        scripts_installed,
         commands_dir,
         version
     );
     Ok(version)
+}
+
+/// Ensure the reconciler Stop/SubagentStop hooks exist in the project's
+/// `.claude/settings.json` without clobbering other settings or other hooks.
+/// Idempotent AND migration-aware: any prior hook entry whose command mentions
+/// `reconcile-state.mjs` is removed before the canonical entry is re-added.
+/// Mirrors `ensureReconcilerHook` in packages/framework/install.js.
+fn ensure_reconciler_hook(project: &Path) -> Result<(), String> {
+    const CMD: &str = "node .claude/tiki/scripts/reconcile-state.mjs --quiet";
+    let settings_path = project.join(".claude").join("settings.json");
+
+    let mut settings: serde_json::Value = if settings_path.exists() {
+        std::fs::read_to_string(&settings_path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_else(|| serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+    if !settings.is_object() {
+        settings = serde_json::json!({});
+    }
+
+    let obj = settings.as_object_mut().unwrap();
+    let hooks = obj
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}));
+    if !hooks.is_object() {
+        *hooks = serde_json::json!({});
+    }
+    let hooks_obj = hooks.as_object_mut().unwrap();
+
+    for event in ["Stop", "SubagentStop"] {
+        let existing = hooks_obj
+            .get(event)
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        // Drop any prior reconcile-state hook group (idempotent + path migration).
+        let mut cleaned: Vec<serde_json::Value> = existing
+            .into_iter()
+            .filter(|group| {
+                let mentions = group
+                    .get("hooks")
+                    .and_then(|h| h.as_array())
+                    .map(|inner| {
+                        inner.iter().any(|h| {
+                            h.get("command")
+                                .and_then(|c| c.as_str())
+                                .map(|c| c.contains("reconcile-state.mjs"))
+                                .unwrap_or(false)
+                        })
+                    })
+                    .unwrap_or(false);
+                !mentions
+            })
+            .collect();
+        cleaned.push(serde_json::json!({
+            "hooks": [ { "type": "command", "command": CMD } ]
+        }));
+        hooks_obj.insert(event.to_string(), serde_json::Value::Array(cleaned));
+    }
+
+    std::fs::create_dir_all(settings_path.parent().unwrap()).map_err(|e| e.to_string())?;
+    let pretty = serde_json::to_string_pretty(&settings).map_err(|e| e.to_string())?;
+    std::fs::write(&settings_path, pretty + "\n").map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 /// Read the installed framework version from `<project>/.tiki/.framework-version`,
@@ -683,4 +774,98 @@ pub fn read_framework_version(project_path: String) -> Result<Option<String>, St
     }
     let contents = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
     Ok(Some(contents.trim().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_project(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("tiki-hook-{}-{}", tag, nanos));
+        std::fs::create_dir_all(dir.join(".claude")).unwrap();
+        dir
+    }
+
+    fn read_settings(project: &Path) -> serde_json::Value {
+        let s = std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    fn reconcile_groups(settings: &serde_json::Value, event: &str) -> usize {
+        settings["hooks"][event]
+            .as_array()
+            .map(|groups| {
+                groups
+                    .iter()
+                    .filter(|g| {
+                        g["hooks"]
+                            .as_array()
+                            .map(|hs| {
+                                hs.iter().any(|h| {
+                                    h["command"]
+                                        .as_str()
+                                        .map(|c| c.contains("reconcile-state.mjs"))
+                                        .unwrap_or(false)
+                                })
+                            })
+                            .unwrap_or(false)
+                    })
+                    .count()
+            })
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn ensure_reconciler_hook_preserves_other_settings_and_is_idempotent() {
+        let project = temp_project("idem");
+        // Pre-existing settings: an unrelated plugin, an OLD reconcile hook at a
+        // different path, and an unrelated PreToolUse hook.
+        let initial = serde_json::json!({
+            "enabledPlugins": { "understand-anything@understand-anything": true },
+            "hooks": {
+                "Stop": [
+                    { "hooks": [ { "type": "command", "command": "node packages/framework/scripts/reconcile-state.mjs --quiet" } ] }
+                ],
+                "PreToolUse": [
+                    { "hooks": [ { "type": "command", "command": "echo unrelated" } ] }
+                ]
+            }
+        });
+        std::fs::write(
+            project.join(".claude").join("settings.json"),
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        // Run twice — must converge (idempotent).
+        ensure_reconciler_hook(&project).unwrap();
+        ensure_reconciler_hook(&project).unwrap();
+
+        let s = read_settings(&project);
+        // Unrelated settings preserved.
+        assert_eq!(s["enabledPlugins"]["understand-anything@understand-anything"], serde_json::json!(true));
+        assert_eq!(s["hooks"]["PreToolUse"].as_array().unwrap().len(), 1);
+        // Exactly one reconcile group per event (old path removed, no duplicate).
+        assert_eq!(reconcile_groups(&s, "Stop"), 1);
+        assert_eq!(reconcile_groups(&s, "SubagentStop"), 1);
+        // New canonical path is what's present.
+        let cmd = s["hooks"]["Stop"][0]["hooks"][0]["command"].as_str().unwrap();
+        assert_eq!(cmd, "node .claude/tiki/scripts/reconcile-state.mjs --quiet");
+
+        std::fs::remove_dir_all(&project).ok();
+    }
+
+    #[test]
+    fn ensure_reconciler_hook_creates_settings_when_absent() {
+        let project = temp_project("absent");
+        ensure_reconciler_hook(&project).unwrap();
+        let s = read_settings(&project);
+        assert_eq!(reconcile_groups(&s, "Stop"), 1);
+        assert_eq!(reconcile_groups(&s, "SubagentStop"), 1);
+        std::fs::remove_dir_all(&project).ok();
+    }
 }

--- a/packages/framework/.claude-plugin/plugin.json
+++ b/packages/framework/.claude-plugin/plugin.json
@@ -1,8 +1,9 @@
 {
-  "name": "tiki-framework",
+  "name": "tiki",
   "description": "GitHub-issue-centric workflow framework for Claude Code",
   "version": "0.7.5",
   "author": {
     "name": "Eric Nichols"
-  }
+  },
+  "hooks": "./hooks/hooks.json"
 }

--- a/packages/framework/__tests__/plugin-distribution.test.mjs
+++ b/packages/framework/__tests__/plugin-distribution.test.mjs
@@ -1,0 +1,86 @@
+// Guards for the plugin/desktop distribution of the reconciler (#251 / epic #244).
+//
+// Two channels deliver the reconciler to installed projects:
+//   - Plugin channel: packages/framework/.claude-plugin/plugin.json + hooks/hooks.json
+//     reference scripts via ${CLAUDE_PLUGIN_ROOT}.
+//   - Copy-install channel: install.js / desktop install_framework copy scripts to
+//     <project>/.claude/tiki/scripts/ and write the hook to settings.json.
+//
+// These tests stand in for `claude plugin validate` (the CLI isn't available in CI):
+// they assert the plugin manifest + hooks file are well-formed and reference a real
+// script, and that the committed dogfood script copies match canonical.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FRAMEWORK = join(__dirname, '..');
+const ROOT = join(FRAMEWORK, '..', '..');
+
+const norm = (s) => s.replace(/\r\n/g, '\n');
+
+test('plugin.json is valid, named "tiki", and references hooks/hooks.json', () => {
+  const plugin = JSON.parse(readFileSync(join(FRAMEWORK, '.claude-plugin', 'plugin.json'), 'utf8'));
+  // Name must be "tiki" so commands namespace as /tiki:* when loaded as a plugin.
+  assert.equal(plugin.name, 'tiki', 'plugin name must be "tiki" to preserve /tiki:* commands');
+  assert.equal(plugin.hooks, './hooks/hooks.json', 'plugin must reference its hooks file');
+});
+
+test('hooks/hooks.json is well-formed with Stop + SubagentStop running the reconciler via ${CLAUDE_PLUGIN_ROOT}', () => {
+  const file = join(FRAMEWORK, 'hooks', 'hooks.json');
+  assert.ok(existsSync(file), 'packages/framework/hooks/hooks.json must exist');
+  const cfg = JSON.parse(readFileSync(file, 'utf8'));
+  assert.ok(cfg.hooks && typeof cfg.hooks === 'object', 'hooks.json must have a top-level "hooks" object');
+
+  for (const event of ['Stop', 'SubagentStop']) {
+    const groups = cfg.hooks[event];
+    assert.ok(Array.isArray(groups) && groups.length > 0, `hooks.json must define ${event}`);
+    const cmd = groups[0].hooks?.[0]?.command;
+    assert.ok(typeof cmd === 'string', `${event} hook must have a command string`);
+    assert.match(cmd, /reconcile-state\.mjs/, `${event} hook must run reconcile-state.mjs`);
+    assert.match(cmd, /\$\{CLAUDE_PLUGIN_ROOT\}/, `${event} hook must resolve via \${CLAUDE_PLUGIN_ROOT}`);
+  }
+
+  // The referenced script must actually exist in the plugin.
+  assert.ok(
+    existsSync(join(FRAMEWORK, 'scripts', 'reconcile-state.mjs')),
+    'hooks.json references scripts/reconcile-state.mjs which must exist',
+  );
+});
+
+test('committed dogfood scripts (.claude/tiki/scripts) match canonical (packages/framework/scripts)', () => {
+  const canonicalDir = join(FRAMEWORK, 'scripts');
+  const installedDir = join(ROOT, '.claude', 'tiki', 'scripts');
+  assert.ok(
+    existsSync(installedDir),
+    `Missing installed scripts at ${installedDir}. Run \`node packages/framework/install.js\` from the repo root.`,
+  );
+
+  const canonical = readdirSync(canonicalDir).filter((f) => f.endsWith('.mjs')).sort();
+  const installed = readdirSync(installedDir).filter((f) => f.endsWith('.mjs')).sort();
+  assert.deepEqual(
+    installed,
+    canonical,
+    'Installed scripts differ from canonical. Run `node packages/framework/install.js` to regenerate.',
+  );
+
+  for (const f of canonical) {
+    const a = norm(readFileSync(join(canonicalDir, f), 'utf8'));
+    const b = norm(readFileSync(join(installedDir, f), 'utf8'));
+    assert.equal(b, a, `Script "${f}" drifted between canonical and .claude/tiki/scripts/. Re-run install.js.`);
+  }
+});
+
+test('command files reference scripts at the installed .claude/tiki/scripts path (not the monorepo path)', () => {
+  const commandsDir = join(FRAMEWORK, 'commands');
+  for (const f of readdirSync(commandsDir).filter((f) => f.endsWith('.md'))) {
+    const content = readFileSync(join(commandsDir, f), 'utf8');
+    assert.ok(
+      !content.includes('packages/framework/scripts/'),
+      `${f} still references the monorepo-only path packages/framework/scripts/ — it won't resolve in installed projects. Use .claude/tiki/scripts/.`,
+    );
+  }
+});

--- a/packages/framework/commands/audit.md
+++ b/packages/framework/commands/audit.md
@@ -143,10 +143,10 @@ If any phase has no `dependencies` field, treat it as an empty list (no deps).
 
 ```bash
 # PASS — record the verdict AND the durable artifact:
-node packages/framework/scripts/mark-audited.mjs {number}
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status executing --to-step AUDIT
+node .claude/tiki/scripts/mark-audited.mjs {number}
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status executing --to-step AUDIT
 # WARN or FAIL — do NOT mark audited; keep planning:
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status planning --to-step AUDIT
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status planning --to-step AUDIT
 ```
 </state-management>
 

--- a/packages/framework/commands/execute.md
+++ b/packages/framework/commands/execute.md
@@ -56,10 +56,10 @@ Update `.tiki/state.json` BEFORE each phase. On failure, set `phase.status: "fai
 
 ```bash
 # Before phase N:
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status executing --to-step EXECUTE --phase-current {N} --phase-total {T} --phase-status executing
 # All phases done:
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status shipping --to-step SHIP
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status shipping --to-step SHIP
 ```
 </state-update-requirement>
 
@@ -72,19 +72,19 @@ EXECUTE fires four lifecycle hooks via the hook runner. Hooks are **opt-in** —
 
 ```bash
 # Once, BEFORE the first phase (after computing the total phase count):
-node packages/framework/scripts/run-hook.mjs pre-execute \
+node .claude/tiki/scripts/run-hook.mjs pre-execute \
   --env TIKI_ISSUE={number} --env TIKI_TITLE="{issue title}" --env TIKI_TOTAL_PHASES={T}
 
 # Immediately BEFORE starting each phase N (after the state.mjs transition):
-node packages/framework/scripts/run-hook.mjs phase-start \
+node .claude/tiki/scripts/run-hook.mjs phase-start \
   --env TIKI_ISSUE={number} --env TIKI_PHASE={N} --env TIKI_PHASE_TITLE="{phase title}"
 
 # Immediately AFTER each phase N returns (status is "completed" | "failed" | "skipped"):
-node packages/framework/scripts/run-hook.mjs phase-complete \
+node .claude/tiki/scripts/run-hook.mjs phase-complete \
   --env TIKI_ISSUE={number} --env TIKI_PHASE={N} --env TIKI_PHASE_STATUS="{phase status}"
 
 # Once, AFTER all phases finish (before the shipping transition):
-node packages/framework/scripts/run-hook.mjs post-execute \
+node .claude/tiki/scripts/run-hook.mjs post-execute \
   --env TIKI_ISSUE={number} --env TIKI_PHASES_COMPLETED={count of completed phases}
 ```
 

--- a/packages/framework/commands/get.md
+++ b/packages/framework/commands/get.md
@@ -26,7 +26,7 @@ Fetch a GitHub issue and display it in a readable format. This is typically the 
 **REQUIRED — run this immediately after fetching the issue (you now have the title), before displaying anything.** This creates the `issue:{number}` entry the desktop app tracks; skip it and the issue never appears in the pipeline. Re-running is a safe no-op. Canonical shape and parent-release detection: see `yolo.md` `<state-management>`.
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status pending --to-step GET --issue-number {number} --issue-title "{title}"
 ```
 

--- a/packages/framework/commands/plan.md
+++ b/packages/framework/commands/plan.md
@@ -164,7 +164,7 @@ Rules:
 **REQUIRED — run this FIRST, before designing any phases.** Set the `issue:{number}` entry to `status: "planning"`, `pipelineStep: "PLAN"` so the desktop pipeline advances to PLAN immediately. Emit it unconditionally as the first action regardless of how this command was invoked; it is a safe no-op if already recorded (shim; see `yolo.md` for the legacy direct-write shape):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status planning --to-step PLAN --issue-number {number} --issue-title "{title}"
 ```
 </early-state-update>
@@ -221,7 +221,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 After writing the plan, set phase progress (`current: 1`, `total: N`, `status: "pending"`). Keep work `status: "planning"` until audit passes.
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status planning --to-step PLAN --phase-current 1 --phase-total {total} --phase-status pending
 ```
 </state-management>

--- a/packages/framework/commands/release.md
+++ b/packages/framework/commands/release.md
@@ -154,7 +154,7 @@ For each issue, derive a likely-touched-files set from its body using these sign
   - `sidebar` → `apps/desktop/src/components/sidebar/**`
   - `footer` / `header` → `apps/desktop/src/components/Header.*`
   - `github API`, `gh CLI`, `rate limit` → `apps/desktop/src-tauri/src/github.rs`
-  - `state.json`, `state shim`, `transition` → `packages/framework/scripts/state.mjs` and `apps/desktop/src-tauri/src/state*.rs`
+  - `state.json`, `state shim`, `transition` → `.claude/tiki/scripts/state.mjs` and `apps/desktop/src-tauri/src/state*.rs`
   - `release.md`, `yolo.md`, `framework command` → `packages/framework/commands/**`
   - `detail panel`, `issue detail` → `apps/desktop/src/components/detail/**`
 - **GitHub labels** — `desktop` widens scope to `apps/desktop/**`, `rust` narrows to `apps/desktop/src-tauri/**`, `framework` narrows to `packages/framework/**`.
@@ -248,14 +248,14 @@ Release lifecycle: **start** → **per-wave** → **ship**. See `yolo.md` `<stat
 
 ```bash
 # Start:
-node packages/framework/scripts/state.mjs transition release:{version} \
+node .claude/tiki/scripts/state.mjs transition release:{version} \
   --to-status executing --to-step EXECUTE --release-version {version} --release-issues "41,42,43"
 # Per wave: update release.currentIssues (array; direct JSON write — shim does not edit nested release.* fields),
 # spawn one Agent per issue with isolation: 'worktree', wait for the wave to drain, then
 # append each completed issue number to release.completedIssues and each worktree branch
 # name to release.completedBranches (also direct JSON writes).
 # Ship:
-node packages/framework/scripts/state.mjs transition release:{version} --to-status shipping --to-step SHIP
+node .claude/tiki/scripts/state.mjs transition release:{version} --to-status shipping --to-step SHIP
 ```
 
 **Release state shape** (additive — `currentIssue` retained for back-compat with serial mode and is ignored when `currentIssues` is set):
@@ -279,17 +279,17 @@ After shipping:
 
 ```bash
 # Remove the release entry from activeWork:
-node packages/framework/scripts/state.mjs remove release:{version}
+node .claude/tiki/scripts/state.mjs remove release:{version}
 # For EACH child issue with parentRelease == {version} (run the next two lines
 # once per child): append it to history.recentIssues FIRST (so the desktop
 # Kanban "Completed" column, which reads recentIssues, shows release-shipped
 # issues — mirrors ship.md), THEN remove it from activeWork. append-history is
 # idempotent on issue number, so this is safe even if ship.md already appended
 # the child during the cascade.
-node packages/framework/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
-node packages/framework/scripts/state.mjs remove issue:{number}
+node .claude/tiki/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
+node .claude/tiki/scripts/state.mjs remove issue:{number}
 # Append the release completion record to history:
-node packages/framework/scripts/state.mjs append-history release --version {version} --issues "41,42,43" --tag {version}
+node .claude/tiki/scripts/state.mjs append-history release --version {version} --issues "41,42,43" --tag {version}
 ```
 
 Then move the release file to `.tiki/releases/archive/` as a regular filesystem rename (no shim involvement — it's not a state.json mutation).

--- a/packages/framework/commands/review.md
+++ b/packages/framework/commands/review.md
@@ -140,7 +140,7 @@ Rules:
 **REQUIRED — run this FIRST, before analyzing the issue.** Record the `pending → reviewing` transition through the validated shim so the desktop pipeline advances to REVIEW immediately. Do NOT defer it to the end of the step or make it conditional on how this command was invoked — emit it unconditionally as the first action. The shim creates the `issue:{number}` entry if missing, updates status/`pipelineStep`/`lastActivity`, preserves `parentRelease`, and is a safe no-op if the step was already recorded.
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status reviewing --to-step REVIEW --issue-number {number} --issue-title "{title}"
 ```
 </state-management>

--- a/packages/framework/commands/ship.md
+++ b/packages/framework/commands/ship.md
@@ -133,12 +133,12 @@ SHIP fires two lifecycle hooks via the hook runner. Hooks are **opt-in** — the
 
 ```bash
 # BEFORE staging/committing (after pre-ship tests pass):
-node packages/framework/scripts/run-hook.mjs pre-ship \
+node .claude/tiki/scripts/run-hook.mjs pre-ship \
   --env TIKI_ISSUE={number} --env TIKI_TITLE="{issue title}"
 
 # AFTER a successful push (capture the commit SHA first):
 SHA=$(git rev-parse HEAD)
-node packages/framework/scripts/run-hook.mjs post-ship \
+node .claude/tiki/scripts/run-hook.mjs post-ship \
   --env TIKI_ISSUE={number} --env TIKI_COMMIT_SHA="$SHA"
 ```
 
@@ -245,13 +245,13 @@ All success criteria verified:
 
 ```bash
 # 1. Mark shipping:
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status shipping --to-step SHIP
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status shipping --to-step SHIP
 # 2a. Release child (entry stays in activeWork; parentRelease preserved):
-node packages/framework/scripts/state.mjs transition issue:{number} --to-status completed --to-step SHIP
+node .claude/tiki/scripts/state.mjs transition issue:{number} --to-status completed --to-step SHIP
 # 2b. Standalone: remove the issue:{number} key from activeWork:
-node packages/framework/scripts/state.mjs remove issue:{number}
+node .claude/tiki/scripts/state.mjs remove issue:{number}
 # 3. In both cases, append the completion record to history:
-node packages/framework/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
+node .claude/tiki/scripts/state.mjs append-history issue --number {number} --title "{issue title}"
 ```
 
 The plan file at `.tiki/plans/issue-{number}.json` is moved to `.tiki/plans/archive/` as a regular filesystem rename (no shim involvement — it's not a state.json mutation).

--- a/packages/framework/commands/yolo.md
+++ b/packages/framework/commands/yolo.md
@@ -141,10 +141,12 @@ The desktop kanban board reads `.tiki/state.json` to render pipeline progress. I
 
 Run the matching block BEFORE dispatching that step. The shim validates transitions, atomic-writes, and preserves `parentRelease`.
 
+**If the shim path does not resolve** (e.g. a plugin-only project where `.claude/tiki/scripts/` was not installed, so `node .claude/tiki/scripts/state.mjs` errors with "Cannot find module"), DO NOT skip the state update — fall back to the direct-JSON write in **Legacy: direct JSON** below. (The reconciler hook still corrects state from artifacts, but emitting the transition keeps the kanban live mid-step.)
+
 **Before GET** (fresh issue — initializes the entry; pass `--issue-number` + `--issue-title` so the work item materializes):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status pending --to-step GET \
   --issue-number {number} --issue-title "{title}"
 ```
@@ -152,14 +154,14 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 **Before REVIEW**:
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status reviewing --to-step REVIEW
 ```
 
 **Before PLAN** (phase total `N` is provisional — re-emit after plan.md writes the real count):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status planning --to-step PLAN \
   --phase-current 1 --phase-total {N} --phase-status pending
 ```
@@ -167,7 +169,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 **Before AUDIT** (same `status: planning`, but `pipelineStep` advances to `AUDIT`):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status planning --to-step AUDIT \
   --phase-current 1 --phase-total {N} --phase-status pending
 ```
@@ -175,7 +177,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 **Before EXECUTE** (each phase — `{current}` is the phase about to run, `{total}` is the plan's phase count):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status executing --to-step EXECUTE \
   --phase-current {current} --phase-total {total} --phase-status executing
 ```
@@ -183,7 +185,7 @@ node packages/framework/scripts/state.mjs transition issue:{number} \
 **Before SHIP** (after all phases pass):
 
 ```bash
-node packages/framework/scripts/state.mjs transition issue:{number} \
+node .claude/tiki/scripts/state.mjs transition issue:{number} \
   --to-status shipping --to-step SHIP
 ```
 

--- a/packages/framework/hooks/hooks.json
+++ b/packages/framework/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "description": "Tiki reconciler — derives pipeline state from artifacts every turn so dropped /tiki transitions self-heal (epic #244). Applies when Tiki is loaded as a Claude Code plugin.",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-state.mjs\" --quiet"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-state.mjs\" --quiet"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/framework/install.js
+++ b/packages/framework/install.js
@@ -2,7 +2,17 @@
 
 /**
  * Tiki Framework Installer
- * Copies Tiki commands to .claude/commands/tiki/ in the target project
+ * Copies Tiki commands + scripts into a target project and registers the
+ * reconciler hook, so the framework works outside the monorepo.
+ *
+ *   .claude/commands/tiki/*.md   ← slash commands
+ *   .claude/tiki/scripts/*.mjs   ← state.mjs / reconcile-state.mjs / etc.
+ *                                  (command bodies + the hook reference this path)
+ *   .claude/settings.json        ← Stop/SubagentStop hook running the reconciler
+ *
+ * This is the "desktop / dogfood copy-install" channel. The other channel is the
+ * Claude Code plugin (packages/framework/.claude-plugin + hooks/hooks.json), which
+ * reaches the scripts via ${CLAUDE_PLUGIN_ROOT}. Either way the reconciler runs.
  */
 
 import { existsSync, mkdirSync, cpSync, readdirSync, readFileSync, writeFileSync } from 'fs';
@@ -12,36 +22,78 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const SOURCE_DIR = join(__dirname, 'commands');
-const TARGET_DIR = join(process.cwd(), '.claude', 'commands', 'tiki');
+const COMMANDS_SOURCE = join(__dirname, 'commands');
+const SCRIPTS_SOURCE = join(__dirname, 'scripts');
+const COMMANDS_TARGET = join(process.cwd(), '.claude', 'commands', 'tiki');
+const SCRIPTS_TARGET = join(process.cwd(), '.claude', 'tiki', 'scripts');
+const SETTINGS_FILE = join(process.cwd(), '.claude', 'settings.json');
 const TIKI_DIR = join(process.cwd(), '.tiki');
 const VERSION_FILE = join(TIKI_DIR, '.framework-version');
 const PLUGIN_JSON = join(__dirname, '.claude-plugin', 'plugin.json');
 
-function install() {
-  console.log('Installing Tiki commands...\n');
+// The reconciler hook command. Project-relative so it resolves from the project
+// root in any installed project (the desktop launches its terminal there).
+const RECONCILE_CMD = 'node .claude/tiki/scripts/reconcile-state.mjs --quiet';
+const HOOK_EVENTS = ['Stop', 'SubagentStop'];
 
-  // Check source exists
-  if (!existsSync(SOURCE_DIR)) {
-    console.error('Error: Source commands directory not found');
+/**
+ * Ensure the reconciler Stop/SubagentStop hooks exist in settings.json without
+ * clobbering other settings or other hooks. Idempotent AND migration-aware: any
+ * prior hook entry whose command mentions reconcile-state.mjs (e.g. an older
+ * path) is removed before the canonical entry is re-added.
+ */
+function ensureReconcilerHook() {
+  let settings = {};
+  if (existsSync(SETTINGS_FILE)) {
+    try {
+      settings = JSON.parse(readFileSync(SETTINGS_FILE, 'utf8'));
+    } catch {
+      settings = {}; // unparseable — start fresh rather than fail the install
+    }
+  }
+  if (typeof settings !== 'object' || settings === null) settings = {};
+  settings.hooks = settings.hooks && typeof settings.hooks === 'object' ? settings.hooks : {};
+
+  for (const event of HOOK_EVENTS) {
+    const groups = Array.isArray(settings.hooks[event]) ? settings.hooks[event] : [];
+    const cleaned = groups.filter((group) => {
+      const inner = group && Array.isArray(group.hooks) ? group.hooks : [];
+      return !inner.some(
+        (h) => h && typeof h.command === 'string' && h.command.includes('reconcile-state.mjs'),
+      );
+    });
+    cleaned.push({ hooks: [{ type: 'command', command: RECONCILE_CMD }] });
+    settings.hooks[event] = cleaned;
+  }
+
+  mkdirSync(dirname(SETTINGS_FILE), { recursive: true });
+  writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2) + '\n');
+}
+
+function copyDir(source, target, ext, label) {
+  if (!existsSync(source)) {
+    console.error(`Error: source directory not found: ${source}`);
     process.exit(1);
   }
-
-  // Create target directory
-  if (!existsSync(TARGET_DIR)) {
-    mkdirSync(TARGET_DIR, { recursive: true });
-    console.log(`Created: ${TARGET_DIR}`);
+  mkdirSync(target, { recursive: true });
+  const files = readdirSync(source).filter((f) => f.endsWith(ext));
+  for (const f of files) {
+    cpSync(join(source, f), join(target, f));
   }
+  console.log(`  Installed ${files.length} ${label} → ${target}`);
+  return files.length;
+}
 
-  // Copy commands
-  const commands = readdirSync(SOURCE_DIR).filter(f => f.endsWith('.md'));
+function install() {
+  console.log('Installing Tiki framework...\n');
 
-  for (const cmd of commands) {
-    const source = join(SOURCE_DIR, cmd);
-    const target = join(TARGET_DIR, cmd);
-    cpSync(source, target);
-    console.log(`  Installed: tiki:${cmd.replace('.md', '')}`);
-  }
+  const commandCount = copyDir(COMMANDS_SOURCE, COMMANDS_TARGET, '.md', 'commands');
+  copyDir(SCRIPTS_SOURCE, SCRIPTS_TARGET, '.mjs', 'scripts');
+
+  // Register the reconciler hook (the enforcement that keeps pipeline state
+  // correct even when an imperative transition is dropped — epic #244).
+  ensureReconcilerHook();
+  console.log(`  Registered reconciler hook (Stop + SubagentStop) in ${SETTINGS_FILE}`);
 
   // Stamp the installed framework version so consumers (desktop app,
   // /tiki:version) can detect when commands are out of date.
@@ -54,9 +106,9 @@ function install() {
     console.log(`  Stamped: .tiki/.framework-version (${version})`);
   }
 
-  console.log(`\nInstalled ${commands.length} commands.`);
+  console.log(`\nInstalled ${commandCount} commands.`);
   console.log('\nAvailable commands:');
-  for (const cmd of commands) {
+  for (const cmd of readdirSync(COMMANDS_SOURCE).filter((f) => f.endsWith('.md'))) {
     console.log(`  /tiki:${cmd.replace('.md', '')}`);
   }
 }


### PR DESCRIPTION
Closes #251. Follows the red-teamed plan on the issue.

Delivers the reconciler enforcement (epic #244) to **installed projects**, not just the monorepo — via whichever channel installed them. The original "consolidate on the plugin channel" direction was disproven in review: `${CLAUDE_PLUGIN_ROOT}` does **not** expand in slash-command bodies (only in hook commands — [#9354](https://github.com/anthropics/claude-code/issues/9354), [#12541](https://github.com/anthropics/claude-code/issues/12541)). So this is a **two-channel** model.

## Plugin channel
- Rename plugin `tiki-framework` → `tiki` (so commands namespace as `/tiki:*` when loaded as a plugin).
- `packages/framework/hooks/hooks.json` defines `Stop` + `SubagentStop` → `node "${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-state.mjs" --quiet` (hooks DO substitute the var; Windows-safe). Scripts already bundle at the plugin root. Format verified against real installed plugins.

## Copy-install channel (desktop `install_framework` + `install.js`)
- Install scripts to `<project>/.claude/tiki/scripts/` (Rust embeds via a new `FRAMEWORK_SCRIPTS` `include_dir!`; `install.js` copies them).
- Write the reconciler hook into `<project>/.claude/settings.json` — **idempotent + migration-aware** (drops any prior `reconcile-state` hook, never clobbers other settings/hooks). Implemented in both Rust (`ensure_reconciler_hook`, with unit tests) and `install.js` (`ensureReconcilerHook`).
- Migrate all 8 command files' shim paths `packages/framework/scripts/` → `.claude/tiki/scripts/` so they resolve in installed projects; add a direct-JSON fallback directive for plugin-only projects.

## Guards (stand in for `claude plugin validate`, which needs the CLI)
- `plugin-distribution.test.mjs`: plugin.json/hooks.json validity, hooks reference a real script, `.claude/tiki/scripts` parity with canonical, and no command file uses the monorepo-only path.
- Rust: hook-merge idempotency / non-clobber / migration tests.

## Verification
framework `node:test` 52 · Rust `cargo test` 45 · clippy `--deny warnings` clean · `pnpm build` clean.

## Notes
- Plugin hooks + the desktop-written hook both require user approval in Claude Code.
- Phase 4 from the early plan (desktop driving `claude plugin install`) was **deliberately not done** — it would add a hard dependency on the `claude` CLI being on PATH. The desktop instead writes the hook into the project's settings.json itself (zero external deps).

Part of #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
