### PR TITLE
fix(releases): serialize archived flag so shipped releases show completed (#259)

### DIFF
--- a/.claude/commands/tiki/release.md
+++ b/.claude/commands/tiki/release.md
@@ -292,7 +292,7 @@ node .claude/tiki/scripts/state.mjs remove issue:{number}
 node .claude/tiki/scripts/state.mjs append-history release --version {version} --issues "41,42,43" --tag {version}
 ```
 
-Then move the release file to `.tiki/releases/archive/` as a regular filesystem rename (no shim involvement — it's not a state.json mutation).
+Then archive the release file: first set its `"status"` to `"shipped"` and add `"shipped": true` plus a `"completedAt"` ISO timestamp, then move it to `.tiki/releases/archive/` as a regular filesystem rename (no shim involvement — it's not a state.json mutation). Setting `status` matters: the desktop derives the "completed" badge from the archive LOCATION, but it falls back to the on-disk `status` if the location-derived `archived` flag is ever unavailable — leaving a stale `"status":"active"` in an archived file is the footgun that caused #258. Keep location and status in agreement.
 </state-management>
 
 <output>
@@ -855,8 +855,11 @@ After all issues complete and changelog is approved, ship the release:
 
 6. **Archive release file**
    - Create `.tiki/releases/archive/` if needed
-   - Move `.tiki/releases/{version}.json` to archive
+   - Set the file's `"status"` to `"shipped"` (do NOT leave it `"active"` — the desktop
+     falls back to this field for the completed badge if the location-derived `archived`
+     flag is unavailable; a stale `"active"` here is the #258 footgun)
    - Add `completedAt` and `shipped: true` to archived file
+   - Move `.tiki/releases/{version}.json` to archive
 
 7. **Prune wave worktrees** — after the tag is pushed and state finalized, remove all per-issue worktrees created during wave dispatch:
    ```bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,94 @@ on:
         type: string
 
 jobs:
+  # Pre-deploy gate. release.yml fires on a tag push and goes straight to building
+  # and publishing platform installers — and most Tiki releases ship direct-to-main
+  # with no PR, so they bypass pr.yml entirely. Without this job the ONLY thing
+  # standing between a tag and published binaries is a manual pre-tag checklist;
+  # that is exactly how #258 shipped (the release meant to FIX the stale-"active"
+  # release badge published without any automated test exercising release status
+  # tracking). This job runs the same core suite as pr.yml and the `release` matrix
+  # `needs:` it, so if any check fails NO installer is built or uploaded. Workflow
+  # tracking is the product's foundation — it must be green before anything deploys.
+  test:
+    name: Pre-deploy gate (core tests)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Configure pnpm store
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install Rust stable + clippy
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/desktop/src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Vitest (packages/shared)
+        run: pnpm -C packages/shared test
+
+      - name: Vitest (apps/desktop)
+        run: pnpm -C apps/desktop test
+
+      - name: Tests (packages/framework)
+        run: pnpm -C packages/framework test
+
+      - name: Cargo test
+        run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
+
+      - name: Cargo clippy
+        run: cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets -- --deny warnings
+
   release:
+    needs: test
     permissions:
       contents: write
     strategy:

--- a/.tiki/releases/archive/v0.7.7.json
+++ b/.tiki/releases/archive/v0.7.7.json
@@ -1,11 +1,13 @@
 {
   "version": "v0.7.7",
-  "status": "active",
+  "status": "shipped",
   "issues": [
     {
       "number": 254,
       "title": "Bug: Terminal bottom row (prompt) renders below the viewport until a keystroke — output path never re-syncs scroll"
     }
   ],
-  "createdAt": "2026-05-23T22:02:09.903Z"
+  "createdAt": "2026-05-23T22:02:09.903Z",
+  "shipped": true,
+  "tag": "v0.7.7"
 }

--- a/.tiki/releases/archive/v0.8.1.json
+++ b/.tiki/releases/archive/v0.8.1.json
@@ -1,6 +1,6 @@
 {
   "version": "v0.8.1",
-  "status": "active",
+  "status": "shipped",
   "issues": [
     {
       "number": 258,
@@ -9,5 +9,6 @@
   ],
   "createdAt": "2026-05-24T19:22:49.461Z",
   "completedAt": "2026-05-24T19:25:25.006Z",
-  "shipped": true
+  "shipped": true,
+  "tag": "v0.8.1"
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -970,6 +970,45 @@ mod tests {
         std::fs::remove_dir_all(&tiki).ok();
     }
 
+    /// REGRESSION GUARD for the #255/#258 bug class — and the one test the prior
+    /// two structurally could NOT catch.
+    ///
+    /// The desktop derives a release's "completed" badge from `TikiRelease.archived`
+    /// (the on-disk `status` stays stale "active" after the ship teardown). Tauri
+    /// serializes IPC command return values with this struct's derived `Serialize`,
+    /// so if `archived` is ever marked `skip_serializing` again it vanishes from the
+    /// payload, the frontend reads `undefined`, and every shipped release shows a
+    /// stale "active" badge.
+    ///
+    /// `load_tiki_releases_marks_archived_by_location_not_status` only inspects the
+    /// in-memory Rust struct (before serialization), so it cannot see an IPC-strip.
+    /// This test exercises the actual wire format: serialize, then assert the key
+    /// survives. If this fails, the desktop's release status tracking is broken even
+    /// when every other test is green — do not "fix" it by relaxing the assertion.
+    #[test]
+    fn tiki_release_archived_survives_serialization() {
+        let release = TikiRelease {
+            version: "v1.2.3".to_string(),
+            name: None,
+            // Archived files keep a stale "active" status — `archived` is the only
+            // reliable completed-signal the frontend has.
+            status: crate::state::TikiReleaseStatus::Active,
+            issues: vec![],
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: None,
+            archived: true,
+        };
+
+        let value = serde_json::to_value(&release).expect("TikiRelease must serialize");
+        assert_eq!(
+            value.get("archived").and_then(|v| v.as_bool()),
+            Some(true),
+            "`archived` must be present in the serialized TikiRelease so it crosses \
+             the Tauri IPC boundary to the frontend — the stale `status` field must \
+             not become the only completed-signal the UI receives (#255/#258)"
+        );
+    }
+
     #[test]
     fn read_release_changelog_reads_top_level_then_archive_else_none() {
         let nanos = std::time::SystemTime::now()

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -599,9 +599,18 @@ pub struct TikiRelease {
     /// True when this release was loaded from `releases/archive/` (i.e. shipped).
     /// Derived from file LOCATION at load time, never from the JSON: the ship
     /// teardown `mv`s a release into `archive/` without flipping `status`, so an
-    /// archived file can still say `"status":"active"`. `skip_serializing` keeps
-    /// this purely derived — it is never written back to disk.
-    #[serde(default, skip_serializing)]
+    /// archived file can still say `"status":"active"`.
+    ///
+    /// MUST stay serialized. Tauri serializes IPC command return values with this
+    /// same derived `Serialize` impl, and the desktop sidebar + detail panel derive
+    /// "completed" from `archived` (the on-disk `status` is unreliable). A
+    /// `skip_serializing` here strips the field from the IPC payload too, so the
+    /// frontend reads `undefined`, falls back to the stale `"active"` status, and
+    /// every shipped release shows a stale "active" badge — the #255/#258 bug class.
+    /// The persisted value is meaningless: `read_release_dir` overwrites it from the
+    /// file's location on every load, so writing it to disk is inert. Guarded by
+    /// `tiki_release_archived_survives_serialization` in `commands.rs`.
+    #[serde(default)]
     pub archived: bool,
 }
 

--- a/apps/desktop/src/components/detail/TikiReleaseDetail.tsx
+++ b/apps/desktop/src/components/detail/TikiReleaseDetail.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { TikiRelease } from "../../stores/tikiReleasesStore";
 import { useTerminalStore, useProjectsStore, useReleaseDialogStore, useTikiReleasesStore, useDetailStore, EMPTY_TABS } from "../../stores";
 import { MarkdownRenderer } from "./MarkdownRenderer";
+import { isReleaseCompleted } from "../../utils/releaseDisplayStatus";
 import "./DetailPanel.css";
 
 interface TikiReleaseDetailProps {
@@ -61,7 +62,8 @@ export function TikiReleaseDetail({ release }: TikiReleaseDetailProps) {
 
   // A release is "completed" once it has shipped (archived) — the archive flag is
   // the reliable signal because the ship teardown leaves the JSON status stale.
-  const isCompleted = release.archived || release.status === "completed" || release.status === "shipped";
+  // Shared with the sidebar via isReleaseCompleted so the two never drift.
+  const isCompleted = isReleaseCompleted(release);
 
   // Header badge: surface "Completed" even when an archived record's status field
   // still says "active" (so it matches the sidebar).

--- a/apps/desktop/src/components/sidebar/ReleasesSection.tsx
+++ b/apps/desktop/src/components/sidebar/ReleasesSection.tsx
@@ -13,6 +13,7 @@ import {
   type TikiRelease,
   type TikiReleaseStatus,
 } from "../../stores";
+import { isReleaseCompleted } from "../../utils/releaseDisplayStatus";
 import "./ReleasesSection.css";
 
 /** Compare two version strings by semver (descending). */
@@ -296,10 +297,15 @@ export function ReleasesSection() {
     // archive/ without flipping its status (so an archived file can still say
     // 'active') — see TikiRelease.archived.
     for (const tiki of tikiReleases) {
-      const tikiDisplay: MergedRelease["displayStatus"] =
-        tiki.archived || tiki.status === "shipped" || tiki.status === "completed"
-          ? "completed"
-          : tiki.status;
+      // 'shipped'/'completed'/archived collapse to 'completed' (displayStatus has
+      // no 'shipped'); the only non-completed statuses that reach here are
+      // 'active'/'not_planned'. Mapped explicitly so tsc -b stays happy without
+      // narrowing through the isReleaseCompleted() boolean.
+      const tikiDisplay: MergedRelease["displayStatus"] = isReleaseCompleted(tiki)
+        ? "completed"
+        : tiki.status === "not_planned"
+          ? "not_planned"
+          : "active";
       const existing = map.get(tiki.version);
       if (existing) {
         existing.status = tiki.status;

--- a/apps/desktop/src/utils/__tests__/releaseDisplayStatus.test.ts
+++ b/apps/desktop/src/utils/__tests__/releaseDisplayStatus.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { isReleaseCompleted } from '../releaseDisplayStatus';
+
+/**
+ * Consumer-side guard for the #255/#258 bug class.
+ *
+ * The Rust `tiki_release_archived_survives_serialization` test guarantees the
+ * `archived` flag crosses the IPC boundary; this guards what the frontend DOES
+ * with it: a shipped release whose on-disk `status` is still the stale "active"
+ * must still render as completed, in BOTH the sidebar and the detail panel (they
+ * now share this single helper, so they can't drift apart again).
+ */
+describe('isReleaseCompleted', () => {
+  it('treats an archived release as completed even when status is the stale "active"', () => {
+    // The exact v0.7.7 / v0.8.1 situation: in archive/, status left at "active".
+    expect(isReleaseCompleted({ archived: true, status: 'active' })).toBe(true);
+  });
+
+  it('treats explicit shipped/completed status as completed (status fallback)', () => {
+    expect(isReleaseCompleted({ archived: false, status: 'shipped' })).toBe(true);
+    expect(isReleaseCompleted({ archived: false, status: 'completed' })).toBe(true);
+    // ...even if archived never arrived (e.g. a Node-written JSON with no flag).
+    expect(isReleaseCompleted({ status: 'shipped' })).toBe(true);
+  });
+
+  it('treats a live, non-archived "active" release as NOT completed', () => {
+    expect(isReleaseCompleted({ archived: false, status: 'active' })).toBe(false);
+    expect(isReleaseCompleted({ status: 'active' })).toBe(false);
+  });
+});

--- a/apps/desktop/src/utils/releaseDisplayStatus.ts
+++ b/apps/desktop/src/utils/releaseDisplayStatus.ts
@@ -1,0 +1,28 @@
+import type { TikiRelease } from "../stores/tikiReleasesStore";
+
+/**
+ * Whether a release should be treated as "completed" (shipped) for display.
+ *
+ * The authoritative signal is the location-derived `archived` flag stamped by the
+ * `load_tiki_releases` Tauri command — the on-disk `status` is unreliable because
+ * the ship teardown moves a release into `releases/archive/` WITHOUT flipping its
+ * `status`, so an archived file can still say `"status":"active"`.
+ *
+ * `archived` only reaches the frontend if it is serialized across the Tauri IPC
+ * boundary; the Rust struct must keep it serializable (see `TikiRelease.archived`
+ * and the `tiki_release_archived_survives_serialization` guard test). We still
+ * accept an explicit `shipped`/`completed` status as a fallback so a
+ * self-consistent JSON also reads as completed even if `archived` is absent.
+ *
+ * Centralizing this avoids the drift that caused the duplicated copies in the
+ * sidebar and the detail panel to disagree. Covered by releaseDisplayStatus.test.ts.
+ */
+export function isReleaseCompleted(
+  release: Pick<TikiRelease, "archived" | "status">
+): boolean {
+  return (
+    Boolean(release.archived) ||
+    release.status === "shipped" ||
+    release.status === "completed"
+  );
+}

--- a/packages/framework/commands/release.md
+++ b/packages/framework/commands/release.md
@@ -292,7 +292,7 @@ node .claude/tiki/scripts/state.mjs remove issue:{number}
 node .claude/tiki/scripts/state.mjs append-history release --version {version} --issues "41,42,43" --tag {version}
 ```
 
-Then move the release file to `.tiki/releases/archive/` as a regular filesystem rename (no shim involvement — it's not a state.json mutation).
+Then archive the release file: first set its `"status"` to `"shipped"` and add `"shipped": true` plus a `"completedAt"` ISO timestamp, then move it to `.tiki/releases/archive/` as a regular filesystem rename (no shim involvement — it's not a state.json mutation). Setting `status` matters: the desktop derives the "completed" badge from the archive LOCATION, but it falls back to the on-disk `status` if the location-derived `archived` flag is ever unavailable — leaving a stale `"status":"active"` in an archived file is the footgun that caused #258. Keep location and status in agreement.
 </state-management>
 
 <output>
@@ -855,8 +855,11 @@ After all issues complete and changelog is approved, ship the release:
 
 6. **Archive release file**
    - Create `.tiki/releases/archive/` if needed
-   - Move `.tiki/releases/{version}.json` to archive
+   - Set the file's `"status"` to `"shipped"` (do NOT leave it `"active"` — the desktop
+     falls back to this field for the completed badge if the location-derived `archived`
+     flag is unavailable; a stale `"active"` here is the #258 footgun)
    - Add `completedAt` and `shipped: true` to archived file
+   - Move `.tiki/releases/{version}.json` to archive
 
 7. **Prune wave worktrees** — after the tag is pushed and state finalized, remove all per-issue worktrees created during wave dispatch:
    ```bash


### PR DESCRIPTION
## What & why

Shipped releases (`v0.7.7`, `v0.8.1`) showed a stale **active** badge in the desktop sidebar and detail panel. Fixes #259 — the true root cause behind #255/#258.

**Root cause:** `TikiRelease.archived` (the location-derived "completed" signal) was `#[serde(skip_serializing)]`. Tauri serializes IPC command return values with the same serde impl, so the flag was stripped before reaching the frontend; the UI then fell back to the on-disk `status`, which the ship teardown leaves stale at `"active"`.

**Decisive evidence:** among the three archived releases with a Tiki JSON, only the two whose on-disk `status` is `"active"` (v0.7.7, v0.8.1) broke; v0.8.0 (`status:"shipped"`) rendered fine — proof the UI was reading `status`, not `archived`.

## Changes

- **Root cause** — `state.rs`: `skip_serializing` → `#[serde(default)]`. The persisted value is inert (`read_release_dir` re-derives `archived` from location on every load).
- **Guard test** — `commands.rs`: `tiki_release_archived_survives_serialization` serializes a `TikiRelease` and asserts the key survives IPC. The prior Rust test only inspected the in-memory struct, so it structurally could not catch an IPC strip.
- **Dedup + test** — new `utils/releaseDisplayStatus.ts` `isReleaseCompleted` helper, shared by the sidebar and detail panel (previously duplicated), with `releaseDisplayStatus.test.ts`.
- **Data + process** — normalized the two stuck archive JSONs to `status:"shipped"`; both finalize paths in `release.md` now set `status` on archive.
- **Pre-deploy gate** — `release.yml` gains a `test` job (mirrors `pr.yml`); the installer build now `needs: test`. Previously the deploy path ran **no** tests, and direct-to-main releases bypassed `pr.yml` entirely — which is how #258 shipped unverified.

## Verification

Local (Windows): `pnpm build` clean · desktop vitest **202** · shared **86** · framework **54** · cargo `--lib` **48** · clippy `--deny warnings` clean.

## Notes

- `archived` is now serialized to disk too (harmless — re-derived on load). Kept `#[serde(default)]` so older archive JSONs and Node-written release files (which have no `archived` key) still deserialize.
- The data-file normalization gives immediate relief: an already-installed v0.8.1 binary reads `status`, so the two releases flip to **completed** on the next sidebar refresh without a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
